### PR TITLE
Refactor update code and run server as same user as updater

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,21 +17,13 @@ RUN dpkg --add-architecture i386 \
         locales \
         unzip \
         zip \
+        rsync \
     && echo 'LANG="en_US.UTF-8"' > /etc/default/locale \
     && echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen \
     && locale-gen \
     && apt-get clean \
-    && adduser \
-        --home /home/steam \
-        --disabled-password \
-        --shell /bin/bash \
-        --gecos "Steam User" \
-        --quiet \
-        steam \
-    && mkdir -p /var/log/supervisor /opt/valheim /opt/steamcmd /home/steam/.config/unity3d/IronGate /config \
-    && ln -s /config /home/steam/.config/unity3d/IronGate/Valheim \
-    && chown -R steam:steam /opt/valheim /home/steam /config \
-    && cd /home/steam \
+    && mkdir -p /var/log/supervisor /opt/valheim /opt/valheim_dl /opt/steamcmd /root/.config/unity3d/IronGate /config \
+    && ln -s /config /root/.config/unity3d/IronGate/Valheim \
     && tar xzvf /tmp/steamcmd_linux.tar.gz -C /opt/steamcmd/ \
     && chown -R root:root /opt/steamcmd \
     && chmod 755 /opt/steamcmd/steamcmd.sh /opt/steamcmd/linux32/steamcmd /opt/steamcmd/linux32/steamerrorreporter \
@@ -43,5 +35,5 @@ COPY supervisord.conf /etc/supervisor/supervisord.conf
 
 VOLUME /config
 EXPOSE 2456-2458/udp
-WORKDIR /home/steam
+WORKDIR /
 CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/supervisord.conf"]

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ $ docker run -d \
     lloesche/valheim-server
 ```
 
+Warning: `SERVER_PASS` must be at least 5 characters long. Otherwise `valheim_server.x86_64` will refuse to start!
+
 A fresh start will take several minutes depending on your Internet connection speed as the container will download the Valheim dedicated server from Steam (~1 GB).
 
 Do not forget to modify `WORLD_NAME` to reflect the name of your world! For existing worlds that is the filename in the `worlds/` folder without the `.db/.fwl` extension.
@@ -49,7 +51,7 @@ For LAN-only play see section [Steam Server Favorites & LAN Play](#steam-server-
 |`SERVER_NAME` | `My Server` | Name that will be shown in the server browser |
 |`SERVER_PORT` | `2456` | UDP start port that the server will listen on |
 |`WORLD_NAME` | `Dedicated` | Name of the world without `.db/.fwl` file extension |
-|`SERVER_PASS` | `secret` | Password for logging into the server |
+|`SERVER_PASS` | `secret` | Password for logging into the server - min. 5 characters! |
 |`SERVER_PUBLIC` | `1` | Whether the server should be listed in the server browser (`1`) or not (`0`) |
 |`UPDATE_INTERVAL` | `900` | How often we check Steam for an updated server version in seconds |
 |`BACKUPS_INTERVAL` | `3600` | Interval in seconds between backup runs |

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -20,8 +20,8 @@ password=dummy
 supervisor.rpcinterface_factory=supervisor.rpcinterface:make_main_rpcinterface
 
 [program:valheim-server]
-user=steam
-environment=HOME="/home/steam",USER="steam",LANG="en_US.UTF-8"
+user=root
+environment=HOME="/root",USER="root",LANG="en_US.UTF-8"
 command=/usr/local/bin/valheim-server
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
@@ -30,7 +30,7 @@ stderr_logfile_maxbytes=0
 autostart=false
 autorestart=true
 startretries=10
-stopwaitsecs=60
+stopwaitsecs=90
 
 [program:valheim-updater]
 user=root

--- a/valheim-server
+++ b/valheim-server
@@ -7,6 +7,8 @@ SERVER_PORT=${SERVER_PORT:-2456}
 WORLD_NAME=${WORLD_NAME:-Dedicated}
 SERVER_PASS=${SERVER_PASS:-secret}
 SERVER_PUBLIC=${SERVER_PUBLIC:-1}
+timeout=20
+kill_signal=TERM
 
 export SteamAppId=892970
 export LD_LIBRARY_PATH="/opt/valheim/linux64/"
@@ -29,10 +31,24 @@ main() {
 shutdown() {
     echo "Shutting down Valheim Server with PID $valheim_server_pid"
     kill -INT $valheim_server_pid
+    shutdown_timeout=$(($(date +%s)+$timeout))
     while [ -d "/proc/$valheim_server_pid" ]; do
-        echo "Waiting for Valheim Server shutdown"
-        sleep 1
+        if [ $(date +%s) -gt $shutdown_timeout ]; then
+            shutdown_timeout=$(($(date +%s)+$timeout))
+            echo "Timeout while waiting for server to shutdown - sending SIG$kill_signal to PID $valheim_server_pid"
+            kill -$kill_signal $valheim_server_pid
+            case "$kill_signal" in
+                INT)
+                    kill_signal=TERM
+                    ;;
+                *)
+                    kill_signal=KILL
+            esac
+        fi
+        echo "Waiting for Valheim Server with PID $valheim_server_pid to shutdown"
+        sleep 3
     done
+    echo "Shutdown complete"
     exit
 }
 

--- a/valheim-updater
+++ b/valheim-updater
@@ -5,35 +5,37 @@ CONFIG_DIRECTORY_PERMISSIONS=${CONFIG_DIRECTORY_PERMISSIONS:-755}
 WORLDS_DIRECTORY_PERMISSIONS=${WORLDS_DIRECTORY_PERMISSIONS:-755}
 WORLDS_FILE_PERMISSIONS=${WORLDS_FILE_PERMISSIONS:-644}
 UPDATE_INTERVAL=${UPDATE_INTERVAL:-900}
-
 just_started=true
+next_update=$(date +%s)
 
 cd /opt/steamcmd
 main() {
     while :; do
         update_permissions
         update
-        sleep $UPDATE_INTERVAL
+        next_update=$(($(date +%s)+$UPDATE_INTERVAL))
+        while [ $(date +%s) -lt $next_update ]; do
+            sleep 3
+        done
     done
 }
 
 update() {
     local logfile="$(mktemp)"
     echo "Updating/Validating Valheim Server"
-    # Valheim dedicated server contains the file server_exit.drp which will make the server shut down / restart
-    # on each update check if validate is being used.
-    # ./steamcmd.sh +login anonymous +force_install_dir /opt/valheim +app_update 896660 validate +quit 2>&1 | tee "$logfile"
-    ./steamcmd.sh +login anonymous +force_install_dir /opt/valheim +app_update 896660 +quit 2>&1 | tee "$logfile"
-    grep downloading "$logfile" > /dev/null 2>&1
+    ./steamcmd.sh +login anonymous +force_install_dir /opt/valheim_dl +app_update 896660 validate +quit
+    rsync -a --itemize-changes --delete --exclude server_exit.drp --exclude steamapps /opt/valheim_dl/ /opt/valheim | tee "$logfile"
+    grep '^[*>]' "$logfile" > /dev/null 2>&1
     if [ $? -eq 0 ]; then
         echo "Valheim Server was updated - restarting"
-        # Update directory permissions so valheim-server running as steam
-        # can create /opt/valheim/server_exit.drp on shutdown.
-        chown steam:steam /opt/valheim
-        supervisorctl restart valheim-server
+        if [ $just_started = true ]; then
+            supervisorctl start valheim-server
+        else
+            supervisorctl restart valheim-server
+        fi
     else
         echo "Valheim Server is already the latest version"
-        if [ $just_started = "true" ]; then
+        if [ $just_started = true ]; then
             supervisorctl start valheim-server
         fi
     fi
@@ -42,13 +44,17 @@ update() {
 }
 
 update_permissions() {
-    chown -R steam:steam /config
     chmod $CONFIG_DIRECTORY_PERMISSIONS /config
     if [ -d /config/worlds ]; then
-        chown -R steam:steam /config/worlds
         chmod $WORLDS_DIRECTORY_PERMISSIONS /config/worlds
         chmod $WORLDS_FILE_PERMISSIONS /config/worlds/*
     fi
 }
 
+update_now() {
+    echo "Received signal to check for update"
+    next_update=$(date +%s)
+}
+
+trap update_now SIGHUP
 main


### PR DESCRIPTION
This should fix https://github.com/lloesche/valheim-server-docker/issues/7 and https://github.com/lloesche/valheim-server-docker/issues/11

`steamcmd` will now run with `validate` again. Instead of grepping the steamcmd log for changes the container now rsyncs changes from the download to the live directory, excluding the `server_exit.drp` file as to not shut down the server every 15 minutes.

The downside is that the container now consumes ~1GB more disk space but I guess the upside of reliable change detection is much higher than a bit of extra disk space.
I experimented with hard linking the files using rsync's `--link-dest` but then `rsync --itemize-changes` doesn't show changes in a usable way. It would also interfere with people who want to volume mount the server directory.

