### PR TITLE
feat(docker): configurable DNS server

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ For LAN-only play see section [Steam Server Favorites & LAN Play](#steam-server-
 |`CONFIG_DIRECTORY_PERMISSIONS` | `755` | Unix permissions for the /config directory |
 |`WORLDS_DIRECTORY_PERMISSIONS` | `755` | Unix permissions for the /config/worlds directory |
 |`WORLDS_FILE_PERMISSIONS` | `644` | Unix permissions for the files in /config/worlds |
+|`DNS_1` | `8.8.8.8` | First DNS server to use for the container to resolve hostnames |
+|`DNS_2` | `8.8.4.4` | Second DNS server to use for the container to resolve hostnames |
 
 
 # Docker+systemd Example
@@ -71,6 +73,8 @@ SERVER_PORT=2456
 WORLD_NAME=Dedicated
 SERVER_PASS=secret
 SERVER_PUBLIC=1
+DNS_1=8.8.8.8
+DNS_2=8.8.4.4
 ```
 
 Then enable the Docker container on system boot

--- a/valheim-server.service
+++ b/valheim-server.service
@@ -5,6 +5,8 @@ Requires=docker.service
 
 [Service]
 TimeoutStartSec=0
+Environment="DNS_1=8.8.8.8"
+Environment="DNS_2=8.8.4.4"
 EnvironmentFile=-/etc/sysconfig/valheim-server
 ExecStartPre=-/usr/bin/docker stop %n
 ExecStartPre=-/usr/bin/docker rm %n
@@ -19,8 +21,8 @@ ExecStart=/usr/bin/docker run \
           -e WORLD_NAME \
           -e SERVER_PASS \
           -e SERVER_PUBLIC \
-          --dns 8.8.8.8 \
-          --dns 8.8.4.4 \
+          --dns $DNS_1 \
+          --dns $DNS_2 \
           lloesche/valheim-server
 ExecStop=/usr/bin/docker stop %n
 Restart=always


### PR DESCRIPTION
- DNS_1 and DNS_2 environment variable added

So now we are able to configure our prefered DNS servers through the `/etc/sysconfig/valheim-server` file if we want to override the defaults.