### PR TITLE
simplistic capability to enable aws and define an s3 path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ RUN dpkg --add-architecture i386 \
         unzip \
         zip \
         rsync \
+        awscli \
     && echo 'LANG="en_US.UTF-8"' > /etc/default/locale \
     && echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen \
     && ln -s /bin/busybox /sbin/syslogd \

--- a/valheim-backup
+++ b/valheim-backup
@@ -6,6 +6,8 @@ BACKUPS_DIRECTORY=${BACKUPS_DIRECTORY:-/config/backups}
 BACKUPS_MAX_AGE=${BACKUPS_MAX_AGE:-3}
 BACKUPS_DIRECTORY_PERMISSIONS=${BACKUPS_DIRECTORY_PERMISSIONS:-755}
 BACKUPS_FILE_PERMISSIONS=${BACKUPS_FILE_PERMISSIONS:-644}
+AWS=${AWS:-false}
+S3_PATH=${S3_PATH:-s3://example-bucket}
 
 # Remove trailing slash if any
 BACKUPS_DIRECTORY=${BACKUPS_DIRECTORY%/}
@@ -31,6 +33,9 @@ backup() {
     chmod $BACKUPS_DIRECTORY_PERMISSIONS "$BACKUPS_DIRECTORY"
     zip -r "$backup_file" "worlds/"
     chmod $BACKUPS_FILE_PERMISSIONS "$backup_file"
+    if [ $AWS == true ]; then
+        aws s3 sync $backup_file $S3_PATH --no-progress
+    fi
 }
 
 flush_old() {


### PR DESCRIPTION
very simple. want to get cleaning of old backups off of s3 working.

adds bloat with awscli in the container, and relies on being in an ec2 to be able to pull the metadata credentials, but I'm running this whole thing on a bare ec2 as a service in an autoscaling group.

I do a few commands at startup to pull the server from bucket, then start up the docker pointing at the files I pulled from s3.

The idea would be that it'd pull the latest backup. Still need to figure out how to do a quick 'shutdown-save-s3-backup' kinda thing, but for now this is better than nothing.