### PR TITLE
Unify all server data under /opt/valheim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN dpkg --add-architecture i386 \
     && ln -s /bin/busybox /usr/bin/wget \
     && locale-gen \
     && apt-get clean \
-    && mkdir -p /var/spool/cron/crontabs /var/log/supervisor /opt/valheim /opt/valheim_dl /opt/steamcmd /root/.config/unity3d/IronGate /config \
+    && mkdir -p /var/spool/cron/crontabs /var/log/supervisor /opt/valheim/server /opt/valheim/dl/server /opt/steamcmd /root/.config/unity3d/IronGate /config \
     && ln -s /config /root/.config/unity3d/IronGate/Valheim \
     && tar xzvf /tmp/steamcmd_linux.tar.gz -C /opt/steamcmd/ \
     && chown -R root:root /opt/steamcmd \
@@ -50,7 +50,7 @@ RUN dpkg --add-architecture i386 \
 COPY supervisord.conf /etc/supervisor/supervisord.conf
 
 ENV TZ=Etc/UTC
-VOLUME ["/config", "/opt/valheim_dl"]
+VOLUME ["/config", "/opt/valheim"]
 EXPOSE 2456-2458/udp
 WORKDIR /
 CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/supervisord.conf"]

--- a/README.md
+++ b/README.md
@@ -11,18 +11,20 @@ The name of the Docker image is `lloesche/valheim-server`.
 Volume mount the server config directory to `/config` within the Docker container.
 
 If you have an existing world on a Windows system you can copy it from e.g.  
-  `C:\Users\Lukas\AppData\LocalLow\IronGate\Valheim\worlds`  
+  `C:\Users\Lukas\AppData\LocalLow\IronGate\Valheim\worlds`
 to e.g.  
-  `$HOME/valheim-server-config/worlds`  
-and run the image with `$HOME/valheim-server-config` volume mounted to `/config` inside the container.
+  `$HOME/valheim-server/config/worlds`
+and run the image with `$HOME/valheim-server/config` volume mounted to `/config` inside the container.
+The container directory `/opt/valheim` contains the downloaded server. It can optionally be volume mounted to avoid having to download the server on each fresh start.
 
 ```
-$ mkdir -p $HOME/valheim-server-config/worlds
+$ mkdir -p $HOME/valheim-server/config/worlds $HOME/valheim-server/data
 # copy existing world
 $ docker run -d \
     --name valheim-server \
     -p 2456-2458:2456-2458/udp \
-    -v $HOME/valheim-server-config:/config \
+    -v $HOME/valheim-server/config:/config \
+    -v $HOME/valheim-server/data:/opt/valheim \
     -e SERVER_NAME="My Server" \
     -e WORLD_NAME="Neotopia" \
     -e SERVER_PASS="secret" \
@@ -88,7 +90,7 @@ DNS_2=8.8.4.4
 
 Then enable the Docker container on system boot
 ```
-$ sudo mkdir /etc/valheim
+$ sudo mkdir -p /etc/valheim /opt/valheim
 $ sudo curl -o /etc/systemd/system/valheim-server.service https://raw.githubusercontent.com/lloesche/valheim-server-docker/master/valheim-server.service
 $ sudo systemctl daemon-reload
 $ sudo systemctl enable valheim-server.service

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,6 +4,7 @@ services:
     image: lloesche/valheim-server
     volumes: 
       - /path/to/valheim/settings:/config
+      - /path/to/valheim/data:/opt/valheim
     ports: 
       - "2456-2458:2456-2458/udp" 
     environment: 

--- a/valheim-bootstrap
+++ b/valheim-bootstrap
@@ -22,4 +22,27 @@ else
     echo "Environment variable RESTART_CRON is empty - no automatic valheim-server restart scheduled"
 fi
 
+# Notify users of new data paths
+if [ -d "/opt/valheim_dl" -o -f "/opt/valheim/valheim_server.x86_64" ]; then
+    cat <<EOF
+!!! ATTENTION !!!
+
+You have /opt/valheim_dl mounted or old server files in /opt/valheim.
+
+The /opt/valheim_dl volume is no longer required and has been unified under
+    /opt/valheim
+
+Directories have been moved in the following way:
+    /opt/valheim/    -> /opt/valheim/server/
+    /opt/valheim_dl/ -> /opt/valheim/dl/server/
+
+You might want to (re)move existing files or create a fresh volume mount under /opt/valheim to clean things up.
+
+Nothing is going to break though if you don't. It will just consume some extra disk space.
+If required we'll download a fresh copy of the server in the new directory structure.
+
+!!! ATTENTION !!!
+EOF
+fi
+
 exit 0

--- a/valheim-server
+++ b/valheim-server
@@ -4,13 +4,13 @@
 . /usr/local/etc/valheim/defaults
 
 cd /opt/valheim
-valheim_server="/opt/valheim/valheim_server.x86_64"
+valheim_server="/opt/valheim/server/valheim_server.x86_64"
 valheim_server_pid=-1
 timeout=20
 kill_signal=TERM
 
 export SteamAppId=892970
-export LD_LIBRARY_PATH="/opt/valheim/linux64/"
+export LD_LIBRARY_PATH="/opt/valheim/server/linux64/"
 
 main() {
     while :; do

--- a/valheim-server.service
+++ b/valheim-server.service
@@ -15,6 +15,7 @@ ExecStart=/usr/bin/docker run \
           --name %n \
           --rm \
           -v /etc/valheim:/config:Z \
+          -v /opt/valheim:/opt/valheim:Z \
           -p 2456-2458:2456-2458/udp \
           -e SERVER_NAME \
           -e SERVER_PORT \

--- a/valheim-updater
+++ b/valheim-updater
@@ -21,9 +21,9 @@ main() {
 
 update() {
     local logfile="$(mktemp)"
-    echo "Updating/Validating Valheim Server"
-    ./steamcmd.sh +login anonymous +force_install_dir /opt/valheim_dl +app_update 896660 $STEAMCMD_ARGS +quit
-    rsync -a --itemize-changes --delete --exclude server_exit.drp --exclude steamapps /opt/valheim_dl/ /opt/valheim | tee "$logfile"
+    echo "Downloading/updating/validating Valheim server from Steam"
+    ./steamcmd.sh +login anonymous +force_install_dir /opt/valheim/dl/server +app_update 896660 $STEAMCMD_ARGS +quit
+    rsync -a --itemize-changes --delete --exclude server_exit.drp --exclude steamapps /opt/valheim/dl/server/ /opt/valheim/server | tee "$logfile"
     grep '^[*>]' "$logfile" > /dev/null 2>&1
     if [ $? -eq 0 ]; then
         echo "Valheim Server was updated - restarting"


### PR DESCRIPTION
Directories have been moved in the following way:
```
    /opt/valheim/    -> /opt/valheim/server/
    /opt/valheim_dl/ -> /opt/valheim/dl/server/
```

This is in preparation of upcoming work where we're adding additional mod files under /opt/valheim and want to have all of the data in a unified location.

Nothing will break for users of the current directory structure. We'll just download a fresh copy of the server to the new location and if we find the old directories or server data we'll show a message on startup notifying them about the changed volume/directory structure.