### PR TITLE
Only update when there are no players connected

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,7 @@ RUN dpkg --add-architecture i386 \
         curl \
         libcurl4 \
         libcurl4:i386 \
+        tcpdump \
         ca-certificates \
         supervisor \
         procps \

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ For more deployment options see the [Deployment section](#deployment).
 | `SERVER_PUBLIC` | `true` | Whether the server should be listed in the server browser (`true`) or not (`false`) |
 | `SERVER_ARGS` |  | Additional Valheim server CLI arguments |
 | `UPDATE_CRON` | `*/15 * * * *` | [Cron schedule](https://en.wikipedia.org/wiki/Cron#Overview) for update checks (disabled if set to an empty string or if the legacy `UPDATE_INTERVAL` is set) |
+| `UPDATE_IF_IDLE` | `false` | Only run update check if no players are connected to the server |
 | `RESTART_CRON` | `0 5 * * *` | [Cron schedule](https://en.wikipedia.org/wiki/Cron#Overview) for server restarts (disabled if set to an empty string) |
 | `TZ` | `Etc/UTC` | Container [time zone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) |
 | `BACKUPS` | `true` | Whether the server should create periodic backups (`true` or `false`) |

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ For more deployment options see the [Deployment section](#deployment).
 | `SERVER_PUBLIC` | `true` | Whether the server should be listed in the server browser (`true`) or not (`false`) |
 | `SERVER_ARGS` |  | Additional Valheim server CLI arguments |
 | `UPDATE_CRON` | `*/15 * * * *` | [Cron schedule](https://en.wikipedia.org/wiki/Cron#Overview) for update checks (disabled if set to an empty string or if the legacy `UPDATE_INTERVAL` is set) |
-| `UPDATE_IF_IDLE` | `false` | Only run update check if no players are connected to the server |
+| `UPDATE_IF_IDLE` | `true` | Only run update check if no players are connected to the server |
 | `RESTART_CRON` | `0 5 * * *` | [Cron schedule](https://en.wikipedia.org/wiki/Cron#Overview) for server restarts (disabled if set to an empty string) |
 | `TZ` | `Etc/UTC` | Container [time zone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) |
 | `BACKUPS` | `true` | Whether the server should create periodic backups (`true` or `false`) |

--- a/defaults
+++ b/defaults
@@ -24,7 +24,7 @@ STEAMCMD_ARGS=${STEAMCMD_ARGS-validate}
 UPDATE_INTERVAL=${UPDATE_INTERVAL:-315360000}
 # When we check for updates
 UPDATE_CRON=${UPDATE_CRON-*/15 * * * *}
-UPDATE_IF_IDLE=${UPDATE_IF_IDLE:-false}
+UPDATE_IF_IDLE=${UPDATE_IF_IDLE:-true}
 
 # What time we restart the valheim-server
 # This is usful to mitigate the effects of memory/resource leaks

--- a/defaults
+++ b/defaults
@@ -24,6 +24,7 @@ STEAMCMD_ARGS=${STEAMCMD_ARGS-validate}
 UPDATE_INTERVAL=${UPDATE_INTERVAL:-315360000}
 # When we check for updates
 UPDATE_CRON=${UPDATE_CRON-*/15 * * * *}
+UPDATE_IF_IDLE=${UPDATE_IF_IDLE:-false}
 
 # What time we restart the valheim-server
 # This is usful to mitigate the effects of memory/resource leaks

--- a/valheim-updater
+++ b/valheim-updater
@@ -38,7 +38,7 @@ main() {
 update() {
     local logfile
     if ! is_idle; then
-        return 1
+        return
     fi
     pre_update_check_hook
     logfile="$(mktemp)"

--- a/valheim-updater
+++ b/valheim-updater
@@ -22,9 +22,7 @@ main() {
         trap 'error_handler $? $LINENO $BASH_LINENO "$BASH_COMMAND" $(printf "::%s" ${FUNCNAME[@]}); trap - ERR' ERR
         while [ $run = true ]; do
             ensure_permissions
-            pre_update_check_hook
             update
-            post_update_check_hook
             check_server_restart
             next_update=$(($(date +%s)+UPDATE_INTERVAL))
             while [ $run = true ] && [ "$(date +%s)" -lt $next_update ]; do
@@ -37,9 +35,12 @@ main() {
     fi
 }
 
-
 update() {
     local logfile
+    if ! is_idle; then
+        return 1
+    fi
+    pre_update_check_hook
     logfile="$(mktemp)"
     info "Downloading/updating/validating Valheim server from Steam"
     download_valheim
@@ -57,6 +58,7 @@ update() {
     fi
     just_started=false
     rm -f "$logfile"
+    post_update_check_hook
 }
 
 
@@ -106,6 +108,20 @@ check_server_restart() {
         supervisorctl "$mode" valheim-server
         post_hook "$mode"
     fi
+}
+
+
+is_idle() {
+    if [ "$UPDATE_IF_IDLE" = true]; then
+        if timeout 3 tcpdump udp port "$SERVER_PORT" -n -s 84 -c 1 > /dev/null 2>&1; then
+            debug "Players connected to Valheim server - skipping update check"
+            return 1
+        else
+            debug "No players connected to Valheim server"
+            return 0
+        fi
+    fi
+    return 0
 }
 
 

--- a/valheim-updater
+++ b/valheim-updater
@@ -112,7 +112,7 @@ check_server_restart() {
 
 
 is_idle() {
-    if [ "$UPDATE_IF_IDLE" = true]; then
+    if [ "$UPDATE_IF_IDLE" = true ]; then
         if timeout 3 tcpdump udp port "$SERVER_PORT" -n -s 84 -c 1 > /dev/null 2>&1; then
             debug "Players connected to Valheim server - skipping update check"
             return 1

--- a/valheim-updater
+++ b/valheim-updater
@@ -113,6 +113,10 @@ check_server_restart() {
 
 is_idle() {
     if [ "$UPDATE_IF_IDLE" = true ]; then
+        if [ "$just_started" = true ]; then
+            debug "Valheim updater was just started - skipping connected players check"
+            return 0
+        fi
         if timeout 3 tcpdump udp port "$SERVER_PORT" -n -s 84 -c 1 > /dev/null 2>&1; then
             debug "Players connected to Valheim server - skipping update check"
             return 1


### PR DESCRIPTION
Adds an option `UPDATE_IF_IDLE`. If set to `true` the update check will only run if no players are connected to the server.