### PR TITLE
Move image from stable to stable-slim and add CAP_SYS_NICE for Steam networking library

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable as build-env
+FROM debian:stable-slim as build-env
 ARG TESTS
 RUN apt-get update
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y install apt-utils
@@ -19,7 +19,7 @@ COPY common /usr/local/etc/valheim/
 COPY contrib/* /usr/local/share/valheim/contrib/
 RUN if [ "${TESTS:-true}" = true ]; then shellcheck -a -x -s bash -e SC2034 /usr/local/sbin/bootstrap /usr/local/bin/valheim-* /usr/local/share/valheim/contrib/*.sh; fi
 
-FROM debian:stable
+FROM debian:stable-slim
 COPY --from=build-env /build/busybox/_install/bin/busybox /usr/local/bin/busybox
 COPY --from=build-env /build/vpenvconf/dist/vpenvconf-*.linux-x86_64.tar.gz /tmp/vpenvconf.tar.gz
 COPY bootstrap /usr/local/sbin/
@@ -56,10 +56,27 @@ RUN dpkg --add-architecture i386 \
     && echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen \
     && ln -s /usr/local/bin/busybox /usr/local/sbin/syslogd \
     && ln -s /usr/local/bin/busybox /usr/local/sbin/crond \
+    && ln -s /usr/local/bin/busybox /usr/local/sbin/mkpasswd \
     && ln -s /usr/local/bin/busybox /usr/local/bin/crontab \
     && ln -s /usr/local/bin/busybox /usr/local/bin/vi \
+    && ln -s /usr/local/bin/busybox /usr/local/bin/patch \
+    && ln -s /usr/local/bin/busybox /usr/local/bin/unix2dos \
+    && ln -s /usr/local/bin/busybox /usr/local/bin/dos2unix \
+    && ln -s /usr/local/bin/busybox /usr/local/bin/makemime \
+    && ln -s /usr/local/bin/busybox /usr/local/bin/xxd \
     && ln -s /usr/local/bin/busybox /usr/local/bin/wget \
     && ln -s /usr/local/bin/busybox /usr/local/bin/less \
+    && ln -s /usr/local/bin/busybox /usr/local/bin/lsof \
+    && ln -s /usr/local/bin/busybox /usr/local/bin/httpd \
+    && ln -s /usr/local/bin/busybox /usr/local/bin/ssl_client \
+    && ln -s /usr/local/bin/busybox /usr/local/bin/ip \
+    && ln -s /usr/local/bin/busybox /usr/local/bin/ipcalc \
+    && ln -s /usr/local/bin/busybox /usr/local/bin/ping \
+    && ln -s /usr/local/bin/busybox /usr/local/bin/ping6 \
+    && ln -s /usr/local/bin/busybox /usr/local/bin/iostat \
+    && ln -s /usr/local/bin/busybox /usr/local/bin/setuidgid \
+    && ln -s /usr/local/bin/busybox /usr/local/bin/ftpget \
+    && ln -s /usr/local/bin/busybox /usr/local/bin/ftpput \
     && rm -f /bin/sh \
     && ln -s /bin/bash /bin/sh \
     && cd / \

--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ This container uses a process supervisor aptly named [`supervisor`](http://super
 Within the container processes can be started and restarted using the command `supervisorctl`. For instance `supervisorctl restart valheim-server` would restart the server.
 
 Supervisor provides a very simple http interface which can be optionally turned on by supplying `SUPERVISOR_HTTP=true` and a password in `SUPERVISOR_HTTP_PASS`.
-The default `SUPERVISOR_HTTP_USER` is `admin` but can be changed to anything else. Once activated the http server will listen on tcp port `9001`.
+The default `SUPERVISOR_HTTP_USER` is `admin` but can be changed to anything else. Once activated the http server will listen on tcp port `9001` which has to be exposed (`-p 9001:9001/tcp`).
 
 ![Supervisor](https://raw.githubusercontent.com/lloesche/valheim-server-docker/main/misc/supervisor.png "Supervisor")
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,12 @@ For LAN-only play see section [Steam Server Favorites & LAN Play](#steam-server-
 
 For more deployment options see the [Deployment section](#deployment). 
 
+Granting `CAP_SYS_NICE` to the container is optional. It allows the Steam networking library that Valheim uses to give itself more CPU cycles.
+Without it you will see a message `Warning: failed to set thread priority` in the startup log. On highly loaded systems it also helps with
+```
+src/steamnetworkingsockets/clientlib/steamnetworkingsockets_lowlevel.cpp (1276) : Assertion Failed: SDR service thread gave up on lock after waiting 60ms. This directly adds to delay of processing of network packets!
+```
+
 
 # Environment Variables
 | Name | Default | Purpose |

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ $ mkdir -p $HOME/valheim-server/config/worlds $HOME/valheim-server/data
 # copy existing world
 $ docker run -d \
     --name valheim-server \
+    --cap-add=sys_nice \
     -p 2456-2458:2456-2458/udp \
     -v $HOME/valheim-server/config:/config \
     -v $HOME/valheim-server/data:/opt/valheim \

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,12 +3,14 @@ version: "3"
 services: 
   valheim: 
     image: lloesche/valheim-server
+    cap_add:
+      - sys_nice
     volumes: 
       - $HOME/valheim-server/config:/config
       - $HOME/valheim-server/data:/opt/valheim
     ports: 
       - "2456-2458:2456-2458/udp"
-      - "9001/tcp"
+      - "9001:9001/tcp"
     env_file:
       - $HOME/valheim-server/valheim.env
     restart: always

--- a/valheim.service
+++ b/valheim.service
@@ -12,6 +12,7 @@ ExecStartPre=/usr/bin/docker pull lloesche/valheim-server
 ExecStart=/usr/bin/docker run \
           --name %n \
           --rm \
+          --cap-add=sys_nice \
           -v /etc/valheim:/config:Z \
           -v /opt/valheim:/opt/valheim:Z \
           -p 2456-2458:2456-2458/udp \


### PR DESCRIPTION
This PR
- moves the image from stable to stable-slim as suggested by @TheCatLady 
- symlinks many busybox applets that might be useful in PRE/POST hooks
- adds CAP_SYS_NICE for the Steam networking library

The last one gets rid of
```
Warning: failed to set thread priority
```
and might help on very loaded systems with https://github.com/lloesche/valheim-server-docker/discussions/104