### PR TITLE
build: Docker optimizations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,6 @@ RUN dpkg --add-architecture i386 \
         jq \
         python3-minimal \
         python3-pkg-resources \
-    && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8 \
     && echo 'LANG="en_US.UTF-8"' > /etc/default/locale \
     && echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen \
     && ln -s /usr/local/bin/busybox /usr/local/sbin/syslogd \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 FROM debian:stable-slim as build-env
+ENV DEBIAN_FRONTEND=noninteractive
 ARG TESTS
 RUN apt-get update
-RUN DEBIAN_FRONTEND=noninteractive apt-get -y install apt-utils
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential curl python3 python3-pip shellcheck
+RUN apt-get -y install apt-utils
+RUN apt-get -y install build-essential curl python3 python3-pip shellcheck
 WORKDIR /build/busybox
 RUN curl -L -o /tmp/busybox.tar.bz2 https://busybox.net/downloads/busybox-1.32.1.tar.bz2
 RUN tar xjvf /tmp/busybox.tar.bz2 --strip-components=1 -C /build/busybox
@@ -20,6 +21,7 @@ COPY contrib/* /usr/local/share/valheim/contrib/
 RUN if [ "${TESTS:-true}" = true ]; then shellcheck -a -x -s bash -e SC2034 /usr/local/sbin/bootstrap /usr/local/bin/valheim-* /usr/local/share/valheim/contrib/*.sh; fi
 
 FROM debian:stable-slim
+ENV DEBIAN_FRONTEND=noninteractive
 COPY --from=build-env /build/busybox/_install/bin/busybox /usr/local/bin/busybox
 COPY --from=build-env /build/vpenvconf/dist/vpenvconf-*.linux-x86_64.tar.gz /tmp/vpenvconf.tar.gz
 COPY bootstrap /usr/local/sbin/
@@ -27,12 +29,11 @@ COPY valheim-* /usr/local/bin/
 COPY defaults /usr/local/etc/valheim/
 COPY common /usr/local/etc/valheim/
 COPY contrib/* /usr/local/share/valheim/contrib/
-ADD https://steamcdn-a.akamaihd.net/client/installer/steamcmd_linux.tar.gz /tmp/
 RUN dpkg --add-architecture i386 \
     && apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get -y install apt-utils \
-    && DEBIAN_FRONTEND=noninteractive apt-get -y dist-upgrade \
-    && DEBIAN_FRONTEND=noninteractive apt-get -y install \
+    && apt-get -y install --no-install-recommends apt-utils \
+    && apt-get -y dist-upgrade \
+    && apt-get -y install --no-install-recommends \
         libc6-dev \
         lib32gcc1 \
         libsdl2-2.0-0 \
@@ -52,6 +53,7 @@ RUN dpkg --add-architecture i386 \
         jq \
         python3-minimal \
         python3-pkg-resources \
+    && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8 \
     && echo 'LANG="en_US.UTF-8"' > /etc/default/locale \
     && echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen \
     && ln -s /usr/local/bin/busybox /usr/local/sbin/syslogd \
@@ -85,6 +87,7 @@ RUN dpkg --add-architecture i386 \
     && apt-get clean \
     && mkdir -p /var/spool/cron/crontabs /var/log/supervisor /opt/valheim /opt/steamcmd /root/.config/unity3d/IronGate /config \
     && ln -s /config /root/.config/unity3d/IronGate/Valheim \
+    && curl -L -o /tmp/steamcmd_linux.tar.gz https://steamcdn-a.akamaihd.net/client/installer/steamcmd_linux.tar.gz \
     && tar xzvf /tmp/steamcmd_linux.tar.gz -C /opt/steamcmd/ \
     && chown -R root:root /opt/steamcmd \
     && chmod 755 /opt/steamcmd/steamcmd.sh \
@@ -97,8 +100,6 @@ RUN dpkg --add-architecture i386 \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 COPY supervisord.conf /etc/supervisor/supervisord.conf
 
-ENV TZ=Etc/UTC
-VOLUME ["/config", "/opt/valheim"]
 EXPOSE 2456-2458/udp
 EXPOSE 9001/tcp
 WORKDIR /

--- a/bootstrap
+++ b/bootstrap
@@ -7,6 +7,7 @@
 
 
 main() {
+    export TZ
     setup_supervisor_http_server
     exec /usr/bin/supervisord -c /etc/supervisor/supervisord.conf
 }


### PR DESCRIPTION
This PR makes some small optimizations to our Docker image and reduces the image size by ~10 MB.  Further optimization is possible but I just wanted to take care of some of the easy things in this PR :)

- set `ENV DEBIAN_FRONTEND=noninteractive` (has the advantage of persisting in the Docker image after build)
- add `--no-install-recommends` in the second build stage to minimize the number of unnecessary packages installed
- ~~add `localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8` to fix the locale gen error~~
- use `curl` to fetch `steamcmd_linux.tar.gz` instead of `COPY`, since `COPY` creates another layer in the final image (when `/tmp` is deleted later, it can't remove stuff from other layers, so currently this tarball is actually present in the final image, albeit hidden)
- consolidate `COPY` commands to reduce number of layers in built image
- remove `VOLUME ["/config", "/opt/valheim"]`, as it is not necessary and only creates an anonymous volume if a volume for `/config` is not defined on container creation
- remove `ENV TZ=Etc/UTC`, since UTC is the default time zone in Docker containers anyway