### PR TITLE
fix: Docker image size bloat

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,8 @@ RUN python3 setup.py bdist --format=gztar
 WORKDIR /build
 RUN git clone https://github.com/Yepoleb/python-a2s.git \
     && cd python-a2s \
-    && python3 setup.py bdist --format=gztar
+    && python3 setup.py bdist --format=gztar \
+    && rm -rf /usr/local/
 COPY bootstrap /usr/local/sbin/
 COPY valheim-* /usr/local/bin/
 COPY defaults /usr/local/etc/valheim/
@@ -37,17 +38,16 @@ RUN if [ "${TESTS:-true}" = true ]; then \
             /usr/local/share/valheim/contrib/*.sh \
         ; \
     fi
-RUN mkdir -p /usr/local/tmp
 WORKDIR /
 RUN mv /build/busybox/_install/bin/busybox /usr/local/bin/busybox
 RUN tar xzvf /build/vpenvconf/dist/vpenvconf-*.linux-x86_64.tar.gz
 RUN tar xzvf /build/python-a2s/dist/python-a2s-*.linux-x86_64.tar.gz
+COPY supervisord.conf /usr/local/
 
 
 FROM debian:stable-slim
 ENV DEBIAN_FRONTEND=noninteractive
 COPY --from=build-env /usr/local/ /usr/local/
-COPY supervisord.conf /etc/supervisor/supervisord.conf.valheim
 RUN dpkg --add-architecture i386 \
     && apt-get update \
     && apt-get -y --no-install-recommends install apt-utils \
@@ -114,7 +114,7 @@ RUN dpkg --add-architecture i386 \
         /opt/steamcmd/linux32/steamerrorreporter \
         /usr/local/sbin/bootstrap \
         /usr/local/bin/valheim-* \
-    && mv -f /etc/supervisor/supervisord.conf.valheim /etc/supervisor/supervisord.conf \
+    && mv -f /usr/local/supervisord.conf /etc/supervisor/supervisord.conf \
     && chmod 600 /etc/supervisor/supervisord.conf \
     && cd "/opt/steamcmd" \
     && ./steamcmd.sh +login anonymous +quit \

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,7 @@ RUN python3 setup.py bdist --format=gztar
 WORKDIR /build
 RUN git clone https://github.com/Yepoleb/python-a2s.git \
     && cd python-a2s \
-    && python3 setup.py bdist --format=gztar \
-    && rm -rf /usr/local/
+    && python3 setup.py bdist --format=gztar
 COPY bootstrap /usr/local/sbin/
 COPY valheim-* /usr/local/bin/
 COPY defaults /usr/local/etc/valheim/
@@ -40,6 +39,7 @@ RUN if [ "${TESTS:-true}" = true ]; then \
     fi
 WORKDIR /
 RUN mv /build/busybox/_install/bin/busybox /usr/local/bin/busybox
+RUN rm -rf /usr/local/lib/
 RUN tar xzvf /build/vpenvconf/dist/vpenvconf-*.linux-x86_64.tar.gz
 RUN tar xzvf /build/python-a2s/dist/python-a2s-*.linux-x86_64.tar.gz
 COPY supervisord.conf /usr/local/


### PR DESCRIPTION
This PR cleans out the `/usr/local` directory before copying files into it, fixing the recent ~10 MB increase in image size.

Also copies the `supervisord.conf` file during the first build stage to avoid creating an extra layer in the final image.