### PR TITLE
add --build flag to docker-compose up command

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ SERVER_PASS=secret
 SERVER_PUBLIC=true
 EOF
 curl -o $HOME/valheim-server/docker-compose.yaml https://raw.githubusercontent.com/lloesche/valheim-server-docker/main/docker-compose.yaml
-docker-compose up
+docker-compose up --build
 ```
 
 ## Deploying to Kubernetes


### PR DESCRIPTION
If you didn't build the image yet you will have to use the `--build` flag.