### PR TITLE
use --pull=always

### DIFF
--- a/valheim.service
+++ b/valheim.service
@@ -8,9 +8,9 @@ ConditionPathExists=/etc/sysconfig/valheim-server
 TimeoutStartSec=0
 ExecStartPre=-/usr/bin/docker stop %n
 ExecStartPre=-/usr/bin/docker rm %n
-ExecStartPre=/usr/bin/docker pull lloesche/valheim-server
 ExecStart=/usr/bin/docker run \
           --name %n \
+          --pull=always \
           --rm \
           --cap-add=sys_nice \
           --stop-timeout 120 \


### PR DESCRIPTION
Docker version 19.09 added some new pull logic[1] to the run command that could be used here
[1]: https://github.com/docker/cli/pull/1498