### PR TITLE
ci: write commit tag to env var

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -45,7 +45,11 @@ jobs:
           file: ./Dockerfile
           platforms: linux/amd64
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ghcr.io/lloesche/valheim-server:latest
+          build-args: |
+            COMMIT_TAG=${{ github.sha }}
+          tags: |
+            ghcr.io/lloesche/valheim-server:latest
+            ghcr.io/lloesche/valheim-server:${{ github.sha }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 


### PR DESCRIPTION
Writes ~~GitHub repository URL, branch, and~~ commit tag/hash to environment variable~~s~~ in the build environment.

Also tags published images with the commit tag/hash.

**Edit:** @lloesche, do we actually need the repository URL or branch name here, or just the commit tag/hash? The method used to obtain the branch name doesn't work for pull requests.