### PR TITLE
Dockerfile: Install uuid package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -101,6 +101,7 @@ RUN dpkg --add-architecture i386 \
         jq \
         python3-minimal \
         python3-pkg-resources \
+        uuid \
     && echo 'LANG="en_US.UTF-8"' > /etc/default/locale \
     && echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen \
     && rm -f /bin/sh \


### PR DESCRIPTION
In order to send Matrix messages via API, a UUID must be supplied. One could use something like `date +%s-%N`, but having the `uuid` command available would be nicer.