### PR TITLE
Allow specifying uid and gid for valheim-server, valheim-updater, and…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -154,6 +154,11 @@ RUN dpkg --add-architecture i386 \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
     && date --utc --iso-8601=seconds > /usr/local/etc/build.date
 
+RUN groupadd -g "${GROUP_ID:-1001}" valheim-server && \
+    useradd -g "${GROUP_ID:-1001}" -u "${USER_ID:-1001}" --create-home valheim-server && \
+    mkdir -p /var/run/valheim && \
+    chown valheim-server:valheim-server /var/run/valheim
+
 EXPOSE 2456-2457/udp
 EXPOSE 9001/tcp
 EXPOSE 80/tcp

--- a/bootstrap
+++ b/bootstrap
@@ -7,12 +7,30 @@
 
 
 main() {
+    apply_permissions
     configure_timezone
     setup_syslog
     setup_supervisor_http_server
     setup_status_http_server
     pre_supervisor_hook
     exec /usr/local/bin/supervisord -c /usr/local/etc/supervisord.conf
+}
+
+
+# Apply user id and group id
+apply_permissions() {
+    if [[ -n "$USER_ID" && -n "$GROUP_ID" ]]; then
+        info "Using uid:gid of valheim-server to $USER_ID:$GROUP_ID"
+        groupmod -g "${GROUP_ID}" valheim-server
+        usermod -u "${USER_ID}" -g valheim-server valheim-server
+        chown "$USER_ID":"$GROUP_ID" \
+            /config \
+            /opt/valheim \
+            /home/valheim-server \
+            /var/run/valheim -R
+        chgrp "$GROUP_ID" /usr/local/etc/supervisord.conf
+        chmod g+r /usr/local/etc/supervisord.conf
+    fi
 }
 
 

--- a/common
+++ b/common
@@ -42,9 +42,9 @@ bepinex_mergefile="$bepinex_download_path/merge" # Signaling file created by val
 bepinex_zipfile=BepInEx.zip                      # Name of the BepInEx archive
 
 # Collection of PID files
-valheim_server_pidfile=/var/run/valheim-server.pid
-valheim_updater_pidfile=/var/run/valheim-updater.pid
-valheim_backup_pidfile=/var/run/valheim-backup.pid
+valheim_server_pidfile=/var/run/valheim/valheim-server.pid
+valheim_updater_pidfile=/var/run/valheim/valheim-updater.pid
+valheim_backup_pidfile=/var/run/valheim/valheim-backup.pid
 
 # Supervisor config files
 supervisor_http_server_conf=/usr/local/etc/supervisor/conf.d/http_server.conf

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -46,8 +46,8 @@ startretries=0
 priority=30
 
 [program:valheim-server]
-user=root
-environment=HOME="/root",USER="root",LANG="en_US.UTF-8",PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+user=valheim-server
+environment=HOME="/home/valheim-server",USER="valheim-server",LANG="en_US.UTF-8",PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 command=/usr/local/bin/valheim-server
 stdout_syslog=true
 stderr_syslog=true
@@ -61,8 +61,8 @@ stopwaitsecs=90
 priority=90
 
 [program:valheim-updater]
-user=root
-environment=HOME="/root",USER="root",LANG="en_US.UTF-8",PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+user=valheim-server
+environment=HOME="/home/valheim-server",USER="valheim-server",LANG="en_US.UTF-8",PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 command=/usr/local/bin/valheim-updater
 stdout_syslog=true
 stderr_syslog=true
@@ -73,8 +73,8 @@ autorestart=true
 priority=50
 
 [program:valheim-backup]
-user=root
-environment=HOME="/root",USER="root",LANG="en_US.UTF-8",PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+user=valheim-server
+environment=HOME="/home/valheim-server",USER="valheim-server",LANG="en_US.UTF-8",PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 command=/usr/local/bin/valheim-backup
 stdout_syslog=true
 stderr_syslog=true


### PR DESCRIPTION
… valheim-backup

Potential fix for #20.

By setting environment variables `USER_ID` and `GROUP_ID` the ids can be adjusted.