### PR TITLE
Specify uid gid (#347)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,6 +82,12 @@ FROM debian:stable-slim
 ENV DEBIAN_FRONTEND=noninteractive
 COPY --from=build-env /usr/local/ /usr/local/
 COPY fake-supervisord /usr/bin/supervisord
+
+RUN groupadd -g "${PGID:-0}" -o valheim-server && \
+    useradd -g "${PGID:-0}" -u "${PUID:-0}" -o --create-home valheim-server && \
+    mkdir -p /var/run/valheim && \
+    chown valheim-server:valheim-server /var/run/valheim
+
 RUN dpkg --add-architecture i386 \
     && apt-get update \
     && apt-get -y --no-install-recommends install apt-utils \
@@ -91,6 +97,7 @@ RUN dpkg --add-architecture i386 \
         lib32gcc1 \
         libsdl2-2.0-0 \
         libsdl2-2.0-0:i386 \
+        cron \
         curl \
         tcpdump \
         libcurl4 \
@@ -112,12 +119,10 @@ RUN dpkg --add-architecture i386 \
     && locale-gen \
     && update-alternatives --install /usr/bin/python python /usr/bin/python3 1 \
     && apt-get clean \
-    && mkdir -p /var/spool/cron/crontabs /var/log/supervisor /opt/valheim /opt/steamcmd /root/.config/unity3d/IronGate /config \
-    && ln -s /config /root/.config/unity3d/IronGate/Valheim \
+    && mkdir -p /var/spool/cron/crontabs /var/log/supervisor /opt/valheim /opt/steamcmd /home/valheim-server/.config/unity3d/IronGate /config \
+    && ln -s /config /home/valheim-server/.config/unity3d/IronGate/Valheim \
     && ln -s /usr/local/bin/busybox /usr/local/sbin/syslogd \
-    && ln -s /usr/local/bin/busybox /usr/local/sbin/crond \
     && ln -s /usr/local/bin/busybox /usr/local/sbin/mkpasswd \
-    && ln -s /usr/local/bin/busybox /usr/local/bin/crontab \
     && ln -s /usr/local/bin/busybox /usr/local/bin/vi \
     && ln -s /usr/local/bin/busybox /usr/local/bin/patch \
     && ln -s /usr/local/bin/busybox /usr/local/bin/unix2dos \

--- a/bootstrap
+++ b/bootstrap
@@ -7,12 +7,36 @@
 
 
 main() {
+    apply_permissions
     configure_timezone
     setup_syslog
     setup_supervisor_http_server
     setup_status_http_server
     pre_supervisor_hook
     exec /usr/local/bin/supervisord -c /usr/local/etc/supervisord.conf
+}
+
+
+# Apply user id and group id
+apply_permissions() {
+    if [[ -n "$PUID" && -n "$PGID" ]]; then
+        info "Setting uid:gid of valheim-server to $PUID:$PGID"
+        groupmod -g "${PGID}" -o valheim-server
+        usermod -u "${PUID}" -o -g valheim-server valheim-server
+
+        mkdir -p /var/run/valheim
+        touch "$SERVER_STATUS_FILE"
+
+        chown "$PUID":"$PGID" -R \
+            /config \
+            /opt/valheim \
+            /opt/steamcmd \
+            /home/valheim-server \
+            /var/run/valheim \
+            "$SERVER_STATUS_FILE"
+        chgrp "$PGID" /usr/local/etc/supervisord.conf
+        chmod g+r /usr/local/etc/supervisord.conf
+    fi
 }
 
 

--- a/common
+++ b/common
@@ -42,9 +42,9 @@ bepinex_mergefile="$bepinex_download_path/merge" # Signaling file created by val
 bepinex_zipfile=BepInEx.zip                      # Name of the BepInEx archive
 
 # Collection of PID files
-valheim_server_pidfile=/var/run/valheim-server.pid
-valheim_updater_pidfile=/var/run/valheim-updater.pid
-valheim_backup_pidfile=/var/run/valheim-backup.pid
+valheim_server_pidfile=/var/run/valheim/valheim-server.pid
+valheim_updater_pidfile=/var/run/valheim/valheim-updater.pid
+valheim_backup_pidfile=/var/run/valheim/valheim-backup.pid
 
 # Supervisor config files
 supervisor_http_server_conf=/usr/local/etc/supervisor/conf.d/http_server.conf

--- a/defaults
+++ b/defaults
@@ -5,6 +5,10 @@
 # The timezone this container is running in
 TZ=${TZ:-Etc/UTC}
 
+# User and group id for the user running valheim-server
+PUID=${PUID:-0}
+PGID=${PGID:-0}
+
 # Valheim dedicated server related values
 WORLD_NAME=${WORLD_NAME:-Dedicated}
 SERVER_NAME=${SERVER_NAME:-My Server}
@@ -105,7 +109,7 @@ SYSLOG_REMOTE_PORT=${SYSLOG_REMOTE_PORT:-514}
 SYSLOG_REMOTE_AND_LOCAL=${SYSLOG_REMOTE_AND_LOCAL:-true}
 
 # Server status
-SERVER_STATUS_FILE=${SERVER_STATUS_FILE:-/var/run/valheim-server.status}
+SERVER_STATUS_FILE=${SERVER_STATUS_FILE:-/var/run/valheim/valheim-server.status}
 
 # Hooks
 PRE_SUPERVISOR_HOOK=${PRE_SUPERVISOR_HOOK:-}

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -7,7 +7,8 @@ childlogdir=/var/log/supervisor
 
 [unix_http_server]
 file=/var/run/supervisor.sock
-chmod=0700
+chmod=0770
+chown=valheim-server:valheim-server
 username=dummy
 password=dummy
 
@@ -22,7 +23,7 @@ supervisor.rpcinterface_factory=supervisor.rpcinterface:make_main_rpcinterface
 [program:crond]
 user=root
 environment=HOME="/root",USER="root",LANG="en_US.UTF-8",PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-command=/usr/local/sbin/crond -f -S
+command=/usr/sbin/cron -f
 stdout_syslog=true
 stderr_syslog=true
 stdout_logfile_maxbytes=1MB
@@ -32,8 +33,8 @@ autorestart=true
 priority=20
 
 [program:valheim-bootstrap]
-user=root
-environment=HOME="/root",USER="root",LANG="en_US.UTF-8",PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+user=valheim-server
+environment=HOME="/home/valheim-server",USER="valheim-server",LANG="en_US.UTF-8",PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 command=/usr/local/bin/valheim-bootstrap
 stdout_syslog=true
 stderr_syslog=true
@@ -46,8 +47,8 @@ startretries=0
 priority=30
 
 [program:valheim-server]
-user=root
-environment=HOME="/root",USER="root",LANG="en_US.UTF-8",PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+user=valheim-server
+environment=HOME="/home/valheim-server",USER="valheim-server",LANG="en_US.UTF-8",PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 command=/usr/local/bin/valheim-server
 stdout_syslog=true
 stderr_syslog=true
@@ -61,8 +62,8 @@ stopwaitsecs=90
 priority=90
 
 [program:valheim-updater]
-user=root
-environment=HOME="/root",USER="root",LANG="en_US.UTF-8",PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+user=valheim-server
+environment=HOME="/home/valheim-server",USER="valheim-server",LANG="en_US.UTF-8",PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 command=/usr/local/bin/valheim-updater
 stdout_syslog=true
 stderr_syslog=true
@@ -73,8 +74,8 @@ autorestart=true
 priority=50
 
 [program:valheim-backup]
-user=root
-environment=HOME="/root",USER="root",LANG="en_US.UTF-8",PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+user=valheim-server
+environment=HOME="/home/valheim-server",USER="valheim-server",LANG="en_US.UTF-8",PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 command=/usr/local/bin/valheim-backup
 stdout_syslog=true
 stderr_syslog=true


### PR DESCRIPTION
* Allow specifying uid and gid for valheim-server, valheim-updater, and valheim-backup

* Using debian cron instead of busybox version

* Adjusted setting of file permissions, valheim-bootstrap now running as valheim-server.