### PR TITLE
Refactor UID:GID code (fixes #355)

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Without it you will see a message `Warning: failed to set thread priority` in th
 
 # Environment Variables
 **All variable names and values are case-sensitive!**
+
 | Name | Default | Purpose |
 |----------|----------|-------|
 | `SERVER_NAME` | `My Server` | Name that will be shown in the server browser |
@@ -152,6 +153,8 @@ Without it you will see a message `Warning: failed to set thread priority` in th
 | `SYSLOG_REMOTE_HOST` |  | Remote syslog host or IP to send logs to |
 | `SYSLOG_REMOTE_PORT` | `514` | Remote syslog UDP port to send logs to |
 | `SYSLOG_REMOTE_AND_LOCAL` | `true` | When sending logs to a remote syslog server also log local |
+| `PUID` | `0` | UID to run valheim-server as |
+| `PGID` | `0` | GID to run valheim-server as |
 
 There are a few undocumented environment variables that could break things if configured wrong. They can be found in [`defaults`](defaults).
 

--- a/bootstrap
+++ b/bootstrap
@@ -19,24 +19,21 @@ main() {
 
 # Apply user id and group id
 apply_permissions() {
-    if [[ -n "$PUID" && -n "$PGID" ]]; then
-        info "Setting uid:gid of valheim-server to $PUID:$PGID"
-        groupmod -g "${PGID}" -o valheim-server
-        usermod -u "${PUID}" -o -g valheim-server valheim-server
+    info "Setting uid:gid of valheim to $PUID:$PGID"
+    groupmod -g "${PGID}" -o valheim
+    #usermod -u "${PUID}" -o -g valheim valheim
+    sed -i -E "s/^(valheim:x):[0-9]+:[0-9]+:(.*)/\\1:$PUID:$PGID:\\2/" /etc/passwd
 
-        mkdir -p /var/run/valheim
-        touch "$SERVER_STATUS_FILE"
+    touch "$SERVER_STATUS_FILE"
 
-        chown "$PUID":"$PGID" -R \
-            /config \
-            /opt/valheim \
-            /opt/steamcmd \
-            /home/valheim-server \
-            /var/run/valheim \
-            "$SERVER_STATUS_FILE"
-        chgrp "$PGID" /usr/local/etc/supervisord.conf
-        chmod g+r /usr/local/etc/supervisord.conf
-    fi
+    chown -R valheim:valheim \
+        /config \
+        /opt/valheim \
+        /opt/steamcmd \
+        /home/valheim \
+        /var/run/valheim \
+        "$SERVER_STATUS_FILE"
+    chgrp valheim /usr/local/etc/supervisord.conf
 }
 
 

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -8,7 +8,7 @@ childlogdir=/var/log/supervisor
 [unix_http_server]
 file=/var/run/supervisor.sock
 chmod=0770
-chown=valheim-server:valheim-server
+chown=valheim:valheim
 username=dummy
 password=dummy
 
@@ -33,8 +33,8 @@ autorestart=true
 priority=20
 
 [program:valheim-bootstrap]
-user=valheim-server
-environment=HOME="/home/valheim-server",USER="valheim-server",LANG="en_US.UTF-8",PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+user=valheim
+environment=HOME="/home/valheim",USER="valheim",LANG="en_US.UTF-8",PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 command=/usr/local/bin/valheim-bootstrap
 stdout_syslog=true
 stderr_syslog=true
@@ -47,8 +47,8 @@ startretries=0
 priority=30
 
 [program:valheim-server]
-user=valheim-server
-environment=HOME="/home/valheim-server",USER="valheim-server",LANG="en_US.UTF-8",PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+user=valheim
+environment=HOME="/home/valheim",USER="valheim",LANG="en_US.UTF-8",PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 command=/usr/local/bin/valheim-server
 stdout_syslog=true
 stderr_syslog=true
@@ -62,8 +62,8 @@ stopwaitsecs=90
 priority=90
 
 [program:valheim-updater]
-user=valheim-server
-environment=HOME="/home/valheim-server",USER="valheim-server",LANG="en_US.UTF-8",PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+user=valheim
+environment=HOME="/home/valheim",USER="valheim",LANG="en_US.UTF-8",PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 command=/usr/local/bin/valheim-updater
 stdout_syslog=true
 stderr_syslog=true
@@ -74,8 +74,8 @@ autorestart=true
 priority=50
 
 [program:valheim-backup]
-user=valheim-server
-environment=HOME="/home/valheim-server",USER="valheim-server",LANG="en_US.UTF-8",PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+user=valheim
+environment=HOME="/home/valheim",USER="valheim",LANG="en_US.UTF-8",PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 command=/usr/local/bin/valheim-backup
 stdout_syslog=true
 stderr_syslog=true


### PR DESCRIPTION
- fixes `usermod: user valheim-server is currently used by process 1` error
- renames `valheim-server` -> `valheim`
- runs steamcmd as correct user in Dockerfile
- updates README.md to include PUID:PGID info
- removes redundant `if` check as PUID:PGID is always set in `defaults`
- reduces number of Docker layers by merging back into a single `RUN` command