### PR TITLE
Ensure binary is executable before launch.

### DIFF
--- a/valheim-server
+++ b/valheim-server
@@ -106,6 +106,7 @@ run_server() {
     debug "Server config is name: $SERVER_NAME, port: $SERVER_PORT/udp, world: $WORLD_NAME, public: $SERVER_PUBLIC, mod: $mod_name"
     update_server_status starting
 
+    chmod +x "$valheim_server"
     # shellcheck disable=SC2086
     LD_PRELOAD=$SERVER_LD_PRELOAD "$valheim_server" -nographics -batchmode -name "$SERVER_NAME" -port "$SERVER_PORT" -world "$WORLD_NAME" -public "$SERVER_PUBLIC" "${password_args[@]}" $SERVER_ARGS > >(filter) 2>&1 &
     valheim_server_pid=$!


### PR DESCRIPTION
Running on Synology, I found that the exec flag was not being set by the steam utilities. Perhaps it should be elsewhere, but just before running seems safe enough to me.