### PR TITLE
Added python3-setuptools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -110,6 +110,7 @@ RUN groupadd -g "${PGID:-0}" -o valheim \
         jq \
         python3-minimal \
         python3-pkg-resources \
+        python3-setuptools \
     && echo 'LANG="en_US.UTF-8"' > /etc/default/locale \
     && echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen \
     && rm -f /bin/sh \


### PR DESCRIPTION
The new version of supervisord seems to require setuptools, see #447.