### PR TITLE
Specify `force_install_dir` before `login` in `steamcmd` call

### DIFF
--- a/valheim-updater
+++ b/valheim-updater
@@ -128,7 +128,7 @@ check_mod() {
 
 download_valheim() {
     # shellcheck disable=SC2086
-    /opt/steamcmd/steamcmd.sh +login anonymous +force_install_dir "$valheim_download_path" +app_update 896660 $STEAMCMD_ARGS +quit
+    /opt/steamcmd/steamcmd.sh +force_install_dir "$valheim_download_path" +login anonymous +app_update 896660 $STEAMCMD_ARGS +quit
 }
 
 


### PR DESCRIPTION
Hey! Thanks for this repo :D 

A change was made to `steamcmd` towards the end of last year, resulting a new warning occuring when calling `steamcmd`. You can see this mentioned in the issue below:

https://github.com/ValveSoftware/steam-for-linux/issues/8298

This PR resolves this issue by simply moving the `+force_install_dir` before the `+login` in the `steamcmd` update call.