### PR TITLE
Fix for update 0.209.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Warning: `SERVER_PASS` must be at least 5 characters long. Otherwise `valheim_se
 
 A fresh start will take several minutes depending on your Internet connection speed as the container will download the Valheim dedicated server from Steam (~1 GB).
 
-Do not forget to modify `WORLD_NAME` to reflect the name of your world! For existing worlds_local that is the filename in the `worlds/` folder without the `.db/.fwl` extension.
+Do not forget to modify `WORLD_NAME` to reflect the name of your world! For existing worlds that is the filename in the `worlds_local/` folder without the `.db/.fwl` extension.
 
 If you want to play with friends over the Internet and are behind NAT make sure that UDP ports 2456-2457 are forwarded to the container host.
 Also ensure they are publicly accessible in any firewall.

--- a/README.md
+++ b/README.md
@@ -69,14 +69,14 @@ The name of the Docker image is `ghcr.io/lloesche/valheim-server`.
 Volume mount the server config directory to `/config` within the Docker container.
 
 If you have an existing world on a Windows system you can copy it from e.g.  
-  `C:\Users\Lukas\AppData\LocalLow\IronGate\Valheim\worlds`
+  `C:\Users\Lukas\AppData\LocalLow\IronGate\Valheim\worlds_local`
 to e.g.  
-  `$HOME/valheim-server/config/worlds`
+  `$HOME/valheim-server/config/worlds_local`
 and run the image with `$HOME/valheim-server/config` volume mounted to `/config` inside the container.
 The container directory `/opt/valheim` contains the downloaded server. It can optionally be volume mounted to avoid having to download the server on each fresh start.
 
 ```
-$ mkdir -p $HOME/valheim-server/config/worlds $HOME/valheim-server/data
+$ mkdir -p $HOME/valheim-server/config/worlds_local $HOME/valheim-server/data
 # copy existing world
 $ docker run -d \
     --name valheim-server \
@@ -95,7 +95,7 @@ Warning: `SERVER_PASS` must be at least 5 characters long. Otherwise `valheim_se
 
 A fresh start will take several minutes depending on your Internet connection speed as the container will download the Valheim dedicated server from Steam (~1 GB).
 
-Do not forget to modify `WORLD_NAME` to reflect the name of your world! For existing worlds that is the filename in the `worlds/` folder without the `.db/.fwl` extension.
+Do not forget to modify `WORLD_NAME` to reflect the name of your world! For existing worlds_local that is the filename in the `worlds/` folder without the `.db/.fwl` extension.
 
 If you want to play with friends over the Internet and are behind NAT make sure that UDP ports 2456-2457 are forwarded to the container host.
 Also ensure they are publicly accessible in any firewall.
@@ -417,20 +417,20 @@ This update schedule can be changed using the `UPDATE_CRON` environment variable
 
 
 # Backups
-The container will on startup and periodically create a backup of the `worlds/` directory.
+The container will on startup and periodically create a backup of the `worlds_local/` directory.
 
 The default is once per hour but can be changed using the `BACKUPS_CRON` environment variable.
 
 Default backup directory is `/config/backups/` within the container. A different directory can be set using the `BACKUPS_DIRECTORY` environment variable.
 It makes sense to have this directory be a volume mount from the host.
-Warning: do not make the backup directory a subfolder of `/config/worlds/`. Otherwise each backup will backup all previous backups.
+Warning: do not make the backup directory a subfolder of `/config/worlds_local/`. Otherwise each backup will backup all previous backups.
 
 By default 3 days worth of backups will be kept. A different number can be configured using `BACKUPS_MAX_AGE`. The value is in days.
 
 It is possible to configure a maximum number of to-be-kept backup files with `BACKUPS_MAX_COUNT`. When going over this limit, the oldest file(s) will be deleted. The default is `0` which means no limit. Note that `BACKUPS_MAX_AGE` will always be respected: if backups get too old, they will be deleted even if `BACKUPS_MAX_COUNT` was not yet reached (or is `0`).
 
 Beware that backups are performed while the server is running. As such files might be in an open state when the backup runs.
-However the `worlds/` directory also contains a `.db.old` file for each world which should always be closed and in a consistent state.
+However the `worlds_local/` directory also contains a `.db.old` file for each world which should always be closed and in a consistent state.
 
 See [Copy backups to another location](#copy-backups-to-another-location) for an example of how to copy backups offsite.
 

--- a/common
+++ b/common
@@ -111,15 +111,16 @@ printline() {
 
 
 get_worlds_dir() {
-    WORLDS_DIR="/config/worlds_local"
+    worlds_dir="/config/worlds_local"
     if [ ! -d "${WORLDS_DIR}" ]; then
         if [ ! -d "/config/worlds" ]; then
             debug "No Valheim worlds to backup"
             return
         else
-            WORLDS_DIR="/config/worlds"
+            worlds_dir="/config/worlds"
         fi
     fi
+    return "$worlds_dir"
 }
 
 

--- a/common
+++ b/common
@@ -118,9 +118,9 @@ ensure_permissions() {
     fi
     chmod "$CONFIG_DIRECTORY_PERMISSIONS" /config
     chmod -f "$CONFIG_FILE_PERMISSIONS" /config/*.txt
-    if [ -d /config/worlds ]; then
-        chmod "$WORLDS_DIRECTORY_PERMISSIONS" /config/worlds
-        chmod "$WORLDS_FILE_PERMISSIONS" /config/worlds/*
+    if [ -d /config/worlds_local ]; then
+        chmod "$WORLDS_DIRECTORY_PERMISSIONS" /config/worlds_local
+        chmod "$WORLDS_FILE_PERMISSIONS" /config/worlds_local/*
     fi
     if [ "$VALHEIM_PLUS" = true ] && [ -d /config/valheimplus ]; then
         find /config/valheimplus -type d -exec chmod "$VALHEIM_PLUS_CONFIG_DIRECTORY_PERMISSIONS" "{}" +

--- a/common
+++ b/common
@@ -134,8 +134,8 @@ ensure_permissions() {
     chmod -f "$CONFIG_FILE_PERMISSIONS" /config/*.txt
     WORLDS_DIR="$(get_worlds_dir)"
     if [ -d "$WORLDS_DIR" ]; then
-        chmod "$WORLDS_DIRECTORY_PERMISSIONS" "/config/${WORLDS_DIR}"
-        chmod "$WORLDS_FILE_PERMISSIONS" "/config/${WORLDS_DIR}/*"
+        chmod "$WORLDS_DIRECTORY_PERMISSIONS" "$WORLDS_DIR"
+        chmod "$WORLDS_FILE_PERMISSIONS" "$WORLDS_DIR/*"
     fi
     if [ "$VALHEIM_PLUS" = true ] && [ -d /config/valheimplus ]; then
         find /config/valheimplus -type d -exec chmod "$VALHEIM_PLUS_CONFIG_DIRECTORY_PERMISSIONS" "{}" +

--- a/common
+++ b/common
@@ -110,6 +110,19 @@ printline() {
 }
 
 
+get_worlds_dir() {
+    WORLDS_DIR="/config/worlds_local"
+    if [ ! -d "${WORLDS_DIR}" ]; then
+        if [ ! -d "/config/worlds" ]; then
+            debug "No Valheim worlds to backup"
+            return
+        else
+            WORLDS_DIR="/config/worlds"
+        fi
+    fi
+}
+
+
 ensure_permissions() {
     local restore_errexit=false
     if [ -o errexit ]; then
@@ -118,9 +131,10 @@ ensure_permissions() {
     fi
     chmod "$CONFIG_DIRECTORY_PERMISSIONS" /config
     chmod -f "$CONFIG_FILE_PERMISSIONS" /config/*.txt
-    if [ -d /config/worlds_local ]; then
-        chmod "$WORLDS_DIRECTORY_PERMISSIONS" /config/worlds_local
-        chmod "$WORLDS_FILE_PERMISSIONS" /config/worlds_local/*
+    WORLDS_DIR="$(get_worlds_dir)"
+    if [ -d "$WORLDS_DIR" ]; then
+        chmod "$WORLDS_DIRECTORY_PERMISSIONS" "/config/${WORLDS_DIR}"
+        chmod "$WORLDS_FILE_PERMISSIONS" "/config/${WORLDS_DIR}/*"
     fi
     if [ "$VALHEIM_PLUS" = true ] && [ -d /config/valheimplus ]; then
         find /config/valheimplus -type d -exec chmod "$VALHEIM_PLUS_CONFIG_DIRECTORY_PERMISSIONS" "{}" +

--- a/common
+++ b/common
@@ -120,7 +120,7 @@ get_worlds_dir() {
             worlds_dir="/config/worlds"
         fi
     fi
-    return "$worlds_dir"
+    echo "$worlds_dir"
 }
 
 

--- a/common
+++ b/common
@@ -135,7 +135,7 @@ ensure_permissions() {
     WORLDS_DIR="$(get_worlds_dir)"
     if [ -d "$WORLDS_DIR" ]; then
         chmod "$WORLDS_DIRECTORY_PERMISSIONS" "$WORLDS_DIR"
-        chmod "$WORLDS_FILE_PERMISSIONS" "$WORLDS_DIR/*"
+        chmod "$WORLDS_FILE_PERMISSIONS" "$WORLDS_DIR/"*
     fi
     if [ "$VALHEIM_PLUS" = true ] && [ -d /config/valheimplus ]; then
         find /config/valheimplus -type d -exec chmod "$VALHEIM_PLUS_CONFIG_DIRECTORY_PERMISSIONS" "{}" +

--- a/common
+++ b/common
@@ -112,7 +112,7 @@ printline() {
 
 get_worlds_dir() {
     worlds_dir="/config/worlds_local"
-    if [ ! -d "${WORLDS_DIR}" ]; then
+    if [ ! -d "${worlds_dir}" ]; then
         if [ ! -d "/config/worlds" ]; then
             debug "No Valheim worlds to backup"
             return
@@ -132,10 +132,10 @@ ensure_permissions() {
     fi
     chmod "$CONFIG_DIRECTORY_PERMISSIONS" /config
     chmod -f "$CONFIG_FILE_PERMISSIONS" /config/*.txt
-    WORLDS_DIR="$(get_worlds_dir)"
-    if [ -d "$WORLDS_DIR" ]; then
-        chmod "$WORLDS_DIRECTORY_PERMISSIONS" "$WORLDS_DIR"
-        chmod "$WORLDS_FILE_PERMISSIONS" "$WORLDS_DIR/"*
+    worlds_dir="$(get_worlds_dir)"
+    if [ -d "$worlds_dir" ]; then
+        chmod "$WORLDS_DIRECTORY_PERMISSIONS" "$worlds_dir"
+        chmod "$WORLDS_FILE_PERMISSIONS" "${worlds_dir}/"*
     fi
     if [ "$VALHEIM_PLUS" = true ] && [ -d /config/valheimplus ]; then
         find /config/valheimplus -type d -exec chmod "$VALHEIM_PLUS_CONFIG_DIRECTORY_PERMISSIONS" "{}" +

--- a/contrib/scp_backup_file.sh
+++ b/contrib/scp_backup_file.sh
@@ -15,8 +15,8 @@
 # BACKUP_SCP_PORT defaults to 22
 # BACKUP_SCP_KEY path to a private key file
 
-# Full path to the worlds backup ZIP we just created
-# e.g. /config/backups/worlds-20210303-144536.zip
+# Full path to the worlds_local backup ZIP we just created
+# e.g. /config/backups/worlds_local-20210303-144536.zip
 backup_file=$1
 
 : "${BACKUP_SCP_USER:=}" "${BACKUP_SCP_HOST:=}" "${BACKUP_SCP_PATH:=}"

--- a/valheim-backup
+++ b/valheim-backup
@@ -1,6 +1,6 @@
 #!/bin/bash
 # valheim-backups runs permanently if BACKUPS=true
-# and creates backups of the /config/worlds directory.
+# and creates backups of the /config/worlds_local directory.
 
 # Include defaults
 . /usr/local/etc/valheim/defaults
@@ -46,8 +46,8 @@ main() {
 
 backup() {
     local backup_file
-    if [ ! -d "/config/worlds" ]; then
-        debug "No Valheim worlds to backup"
+    if [ ! -d "/config/worlds_local" ]; then
+        debug "No Valheim worlds_local to backup"
         return
     fi
 
@@ -55,42 +55,42 @@ backup() {
     chmod "$BACKUPS_DIRECTORY_PERMISSIONS" "$BACKUPS_DIRECTORY"
 
     if [ "${BACKUPS_ZIP}" = true ]; then
-        backup_file="$BACKUPS_DIRECTORY/worlds-$(date +%Y%m%d-%H%M%S).zip"
+        backup_file="$BACKUPS_DIRECTORY/worlds_local-$(date +%Y%m%d-%H%M%S).zip"
         pre_backup_hook "$backup_file"
-        info "Backing up Valheim server worlds to $backup_file"
-        zip -r "$backup_file" "worlds/"
+        info "Backing up Valheim server worlds_local to $backup_file"
+        zip -r "$backup_file" "worlds_local/"
         chmod "$BACKUPS_FILE_PERMISSIONS" "$backup_file"
         post_backup_hook "$backup_file"
     else
-        find worlds/ -name "${WORLD_NAME}.db" -type f || info "Could not find .db world file for world ${WORLD_NAME}"
+        find worlds_local/ -name "${WORLD_NAME}.db" -type f || info "Could not find .db world file for world ${WORLD_NAME}"
         backup_file="$BACKUPS_DIRECTORY/AUTOBACKUP-${WORLD_NAME}-$(date +%Y%m%d-%H%M%S).db"
         pre_backup_hook "$backup_file"
         info "Backing up Valheim server world file ${WORLD_NAME}.db to $backup_file"
-        cp -v "worlds/${WORLD_NAME}.db" "${backup_file}"
+        cp -v "worlds_local/${WORLD_NAME}.db" "${backup_file}"
         chmod "$BACKUPS_FILE_PERMISSIONS" "$backup_file"
         post_backup_hook "$backup_file"
         
-        find worlds/ -name "${WORLD_NAME}.fwl" -type f || info "Could not find .fwl file for world ${WORLD_NAME}"
+        find worlds_local/ -name "${WORLD_NAME}.fwl" -type f || info "Could not find .fwl file for world ${WORLD_NAME}"
         backup_file="$BACKUPS_DIRECTORY/AUTOBACKUP-${WORLD_NAME}-$(date +%Y%m%d-%H%M%S).fwl"
         pre_backup_hook "$backup_file"
         info "Backing up Valheim server .fwl file ${WORLD_NAME}.fwl to $backup_file"
-        cp -v "worlds/${WORLD_NAME}.fwl" "${backup_file}"
+        cp -v "worlds_local/${WORLD_NAME}.fwl" "${backup_file}"
         chmod "$BACKUPS_FILE_PERMISSIONS" "$backup_file"
         post_backup_hook "$backup_file"
         
-        find worlds/ -name "${WORLD_NAME}.db.old" -type f || info "Could not find .db.old world file for world ${WORLD_NAME}"
+        find worlds_local/ -name "${WORLD_NAME}.db.old" -type f || info "Could not find .db.old world file for world ${WORLD_NAME}"
         backup_file="$BACKUPS_DIRECTORY/AUTOBACKUP-${WORLD_NAME}-$(date +%Y%m%d-%H%M%S).db.old"
         pre_backup_hook "$backup_file"
         info "Backing up Valheim server world file ${WORLD_NAME}.db.old to $backup_file"
-        cp -v "worlds/${WORLD_NAME}.db.old" "${backup_file}"
+        cp -v "worlds_local/${WORLD_NAME}.db.old" "${backup_file}"
         chmod "$BACKUPS_FILE_PERMISSIONS" "$backup_file"
         post_backup_hook "$backup_file"
         
-        find worlds/ -name "${WORLD_NAME}.fwl.old" -type f || info "Could not find .fwl.old file for world ${WORLD_NAME}"
+        find worlds_local/ -name "${WORLD_NAME}.fwl.old" -type f || info "Could not find .fwl.old file for world ${WORLD_NAME}"
         backup_file="$BACKUPS_DIRECTORY/AUTOBACKUP-${WORLD_NAME}-$(date +%Y%m%d-%H%M%S).fwl.old"
         pre_backup_hook "$backup_file"
         info "Backing up Valheim server .fwl.old file ${WORLD_NAME}.fwl.old to $backup_file"
-        cp -v "worlds/${WORLD_NAME}.fwl.old" "${backup_file}"
+        cp -v "worlds_local/${WORLD_NAME}.fwl.old" "${backup_file}"
         chmod "$BACKUPS_FILE_PERMISSIONS" "$backup_file"
         post_backup_hook "$backup_file"
         
@@ -130,17 +130,17 @@ flush_old() {
     if [ "$BACKUPS_MAX_COUNT" -gt 0 ]; then
         info "Removing all but the newest $BACKUPS_MAX_COUNT backups"
         if [ "${BACKUPS_ZIP}" = true ]; then
-          find "$BACKUPS_DIRECTORY" -type f -name 'worlds-*.zip' -printf '%T@ %p\0' | sort -z -n -r | cut -z -s -d " " -f "2-" | tail -z -n +$((BACKUPS_MAX_COUNT+1)) | xargs -0 rm -v --
+          find "$BACKUPS_DIRECTORY" -type f -name 'worlds_local-*.zip' -printf '%T@ %p\0' | sort -z -n -r | cut -z -s -d " " -f "2-" | tail -z -n +$((BACKUPS_MAX_COUNT+1)) | xargs -0 rm -v --
         else
           find "$BACKUPS_DIRECTORY" -type f -name "AUTOBACKUP-${WORLD_NAME}-*.db" -printf '%T@ %p\0' | sort -z -n -r | cut -z -s -d " " -f "2-" | tail -z -n +$((BACKUPS_MAX_COUNT+1)) | xargs -0 rm -v --
           find "$BACKUPS_DIRECTORY" -type f -name "AUTOBACKUP-${WORLD_NAME}-*.db.old" -printf '%T@ %p\0' | sort -z -n -r | cut -z -s -d " " -f "2-" | tail -z -n +$((BACKUPS_MAX_COUNT+1)) | xargs -0 rm -v --        
         fi
-        find "$BACKUPS_DIRECTORY" -type f -name 'worlds-*.zip' -printf '%T@ %p\0' | sort -z -n -r | cut -z -s -d " " -f "2-" | tail -z -n +$((BACKUPS_MAX_COUNT+1)) | xargs -0 rm -fv --
+        find "$BACKUPS_DIRECTORY" -type f -name 'worlds_local-*.zip' -printf '%T@ %p\0' | sort -z -n -r | cut -z -s -d " " -f "2-" | tail -z -n +$((BACKUPS_MAX_COUNT+1)) | xargs -0 rm -fv --
     fi
 
     info "Removing backups older than $BACKUPS_MAX_AGE days"
     if [ "${BACKUPS_ZIP}" = true ]; then
-      find "$BACKUPS_DIRECTORY" -type f -mmin "+$((BACKUPS_MAX_AGE*60*24))" -name 'worlds-*.zip' -print -exec rm -f "{}" \;
+      find "$BACKUPS_DIRECTORY" -type f -mmin "+$((BACKUPS_MAX_AGE*60*24))" -name 'worlds_local-*.zip' -print -exec rm -f "{}" \;
     else
       find "$BACKUPS_DIRECTORY" -type f -mmin "+$((BACKUPS_MAX_AGE*60*24))" -name "AUTOBACKUP-${WORLD_NAME}-*.db" -print -exec rm -f "{}" \;
       find "$BACKUPS_DIRECTORY" -type f -mmin "+$((BACKUPS_MAX_AGE*60*24))" -name "AUTOBACKUP-${WORLD_NAME}-*.db.old" -print -exec rm -f "{}" \;

--- a/valheim-backup
+++ b/valheim-backup
@@ -46,51 +46,52 @@ main() {
 
 backup() {
     local backup_file
-    if [ ! -d "/config/worlds_local" ]; then
-        debug "No Valheim worlds_local to backup"
+    WORLDS_DIR=$(get_worlds_dir)
+
+    if [ "${WORLDS_DIR}z" = "z" ]; then
         return
     fi
-
+    
     mkdir -p "$BACKUPS_DIRECTORY"
     chmod "$BACKUPS_DIRECTORY_PERMISSIONS" "$BACKUPS_DIRECTORY"
 
     if [ "${BACKUPS_ZIP}" = true ]; then
-        backup_file="$BACKUPS_DIRECTORY/worlds_local-$(date +%Y%m%d-%H%M%S).zip"
+        backup_file="$BACKUPS_DIRECTORY/$WORLDS_DIR-$(date +%Y%m%d-%H%M%S).zip"
         pre_backup_hook "$backup_file"
-        info "Backing up Valheim server worlds_local to $backup_file"
-        zip -r "$backup_file" "worlds_local/"
+        info "Backing up Valheim server worlds to $backup_file"
+        zip -r "$backup_file" "$WORLDS_DIR/"
         chmod "$BACKUPS_FILE_PERMISSIONS" "$backup_file"
         post_backup_hook "$backup_file"
     else
-        find worlds_local/ -name "${WORLD_NAME}.db" -type f || info "Could not find .db world file for world ${WORLD_NAME}"
+        find "${WORLDS_DIR}/" -name "${WORLD_NAME}.db" -type f || info "Could not find .db world file for world ${WORLD_NAME}"
         backup_file="$BACKUPS_DIRECTORY/AUTOBACKUP-${WORLD_NAME}-$(date +%Y%m%d-%H%M%S).db"
         pre_backup_hook "$backup_file"
         info "Backing up Valheim server world file ${WORLD_NAME}.db to $backup_file"
-        cp -v "worlds_local/${WORLD_NAME}.db" "${backup_file}"
+        cp -v "${WORLDS_DIR}/${WORLD_NAME}.db" "${backup_file}"
         chmod "$BACKUPS_FILE_PERMISSIONS" "$backup_file"
         post_backup_hook "$backup_file"
         
-        find worlds_local/ -name "${WORLD_NAME}.fwl" -type f || info "Could not find .fwl file for world ${WORLD_NAME}"
+        find "${WORLDS_LOCAL}/" -name "${WORLD_NAME}.fwl" -type f || info "Could not find .fwl file for world ${WORLD_NAME}"
         backup_file="$BACKUPS_DIRECTORY/AUTOBACKUP-${WORLD_NAME}-$(date +%Y%m%d-%H%M%S).fwl"
         pre_backup_hook "$backup_file"
         info "Backing up Valheim server .fwl file ${WORLD_NAME}.fwl to $backup_file"
-        cp -v "worlds_local/${WORLD_NAME}.fwl" "${backup_file}"
+        cp -v "${WORLDS_DIR}/${WORLD_NAME}.fwl" "${backup_file}"
         chmod "$BACKUPS_FILE_PERMISSIONS" "$backup_file"
         post_backup_hook "$backup_file"
         
-        find worlds_local/ -name "${WORLD_NAME}.db.old" -type f || info "Could not find .db.old world file for world ${WORLD_NAME}"
+        find "${WORLDS_DIR}/" -name "${WORLD_NAME}.db.old" -type f || info "Could not find .db.old world file for world ${WORLD_NAME}"
         backup_file="$BACKUPS_DIRECTORY/AUTOBACKUP-${WORLD_NAME}-$(date +%Y%m%d-%H%M%S).db.old"
         pre_backup_hook "$backup_file"
         info "Backing up Valheim server world file ${WORLD_NAME}.db.old to $backup_file"
-        cp -v "worlds_local/${WORLD_NAME}.db.old" "${backup_file}"
+        cp -v "${WORLDS_DIR}/${WORLD_NAME}.db.old" "${backup_file}"
         chmod "$BACKUPS_FILE_PERMISSIONS" "$backup_file"
         post_backup_hook "$backup_file"
         
-        find worlds_local/ -name "${WORLD_NAME}.fwl.old" -type f || info "Could not find .fwl.old file for world ${WORLD_NAME}"
+        find "${WORLDS_DIR}/" -name "${WORLD_NAME}.fwl.old" -type f || info "Could not find .fwl.old file for world ${WORLD_NAME}"
         backup_file="$BACKUPS_DIRECTORY/AUTOBACKUP-${WORLD_NAME}-$(date +%Y%m%d-%H%M%S).fwl.old"
         pre_backup_hook "$backup_file"
         info "Backing up Valheim server .fwl.old file ${WORLD_NAME}.fwl.old to $backup_file"
-        cp -v "worlds_local/${WORLD_NAME}.fwl.old" "${backup_file}"
+        cp -v "${WORLDS_DIR}/${WORLD_NAME}.fwl.old" "${backup_file}"
         chmod "$BACKUPS_FILE_PERMISSIONS" "$backup_file"
         post_backup_hook "$backup_file"
         
@@ -127,20 +128,22 @@ flush_old() {
         return
     fi
 
+    WORLDS_DIR=$(get_worlds_dir)
+
     if [ "$BACKUPS_MAX_COUNT" -gt 0 ]; then
         info "Removing all but the newest $BACKUPS_MAX_COUNT backups"
         if [ "${BACKUPS_ZIP}" = true ]; then
-          find "$BACKUPS_DIRECTORY" -type f -name 'worlds_local-*.zip' -printf '%T@ %p\0' | sort -z -n -r | cut -z -s -d " " -f "2-" | tail -z -n +$((BACKUPS_MAX_COUNT+1)) | xargs -0 rm -v --
+          find "$BACKUPS_DIRECTORY" -type f -name "${WORLDS_DIR}-*.zip" -printf '%T@ %p\0' | sort -z -n -r | cut -z -s -d " " -f "2-" | tail -z -n +$((BACKUPS_MAX_COUNT+1)) | xargs -0 rm -v --
         else
           find "$BACKUPS_DIRECTORY" -type f -name "AUTOBACKUP-${WORLD_NAME}-*.db" -printf '%T@ %p\0' | sort -z -n -r | cut -z -s -d " " -f "2-" | tail -z -n +$((BACKUPS_MAX_COUNT+1)) | xargs -0 rm -v --
           find "$BACKUPS_DIRECTORY" -type f -name "AUTOBACKUP-${WORLD_NAME}-*.db.old" -printf '%T@ %p\0' | sort -z -n -r | cut -z -s -d " " -f "2-" | tail -z -n +$((BACKUPS_MAX_COUNT+1)) | xargs -0 rm -v --        
         fi
-        find "$BACKUPS_DIRECTORY" -type f -name 'worlds_local-*.zip' -printf '%T@ %p\0' | sort -z -n -r | cut -z -s -d " " -f "2-" | tail -z -n +$((BACKUPS_MAX_COUNT+1)) | xargs -0 rm -fv --
+        find "$BACKUPS_DIRECTORY" -type f -name "${WORLDS_DIR}-*.zip" -printf '%T@ %p\0' | sort -z -n -r | cut -z -s -d " " -f "2-" | tail -z -n +$((BACKUPS_MAX_COUNT+1)) | xargs -0 rm -fv --
     fi
 
     info "Removing backups older than $BACKUPS_MAX_AGE days"
     if [ "${BACKUPS_ZIP}" = true ]; then
-      find "$BACKUPS_DIRECTORY" -type f -mmin "+$((BACKUPS_MAX_AGE*60*24))" -name 'worlds_local-*.zip' -print -exec rm -f "{}" \;
+      find "$BACKUPS_DIRECTORY" -type f -mmin "+$((BACKUPS_MAX_AGE*60*24))" -name "${WORLDS_DIR}-*.zip" -print -exec rm -f "{}" \;
     else
       find "$BACKUPS_DIRECTORY" -type f -mmin "+$((BACKUPS_MAX_AGE*60*24))" -name "AUTOBACKUP-${WORLD_NAME}-*.db" -print -exec rm -f "{}" \;
       find "$BACKUPS_DIRECTORY" -type f -mmin "+$((BACKUPS_MAX_AGE*60*24))" -name "AUTOBACKUP-${WORLD_NAME}-*.db.old" -print -exec rm -f "{}" \;

--- a/valheim-backup
+++ b/valheim-backup
@@ -56,7 +56,7 @@ backup() {
     chmod "$BACKUPS_DIRECTORY_PERMISSIONS" "$BACKUPS_DIRECTORY"
 
     if [ "${BACKUPS_ZIP}" = true ]; then
-        backup_file="$BACKUPS_DIRECTORY/$WORLDS_DIR-$(date +%Y%m%d-%H%M%S).zip"
+        backup_file="$BACKUPS_DIRECTORY/worlds-$(date +%Y%m%d-%H%M%S).zip"
         pre_backup_hook "$backup_file"
         info "Backing up Valheim server worlds to $backup_file"
         zip -r "$backup_file" "$WORLDS_DIR/"
@@ -133,17 +133,17 @@ flush_old() {
     if [ "$BACKUPS_MAX_COUNT" -gt 0 ]; then
         info "Removing all but the newest $BACKUPS_MAX_COUNT backups"
         if [ "${BACKUPS_ZIP}" = true ]; then
-          find "$BACKUPS_DIRECTORY" -type f -name "${WORLDS_DIR}-*.zip" -printf '%T@ %p\0' | sort -z -n -r | cut -z -s -d " " -f "2-" | tail -z -n +$((BACKUPS_MAX_COUNT+1)) | xargs -0 rm -v --
+          find "$BACKUPS_DIRECTORY" -type f -name "worlds-*.zip" -printf '%T@ %p\0' | sort -z -n -r | cut -z -s -d " " -f "2-" | tail -z -n +$((BACKUPS_MAX_COUNT+1)) | xargs -0 rm -v --
         else
           find "$BACKUPS_DIRECTORY" -type f -name "AUTOBACKUP-${WORLD_NAME}-*.db" -printf '%T@ %p\0' | sort -z -n -r | cut -z -s -d " " -f "2-" | tail -z -n +$((BACKUPS_MAX_COUNT+1)) | xargs -0 rm -v --
           find "$BACKUPS_DIRECTORY" -type f -name "AUTOBACKUP-${WORLD_NAME}-*.db.old" -printf '%T@ %p\0' | sort -z -n -r | cut -z -s -d " " -f "2-" | tail -z -n +$((BACKUPS_MAX_COUNT+1)) | xargs -0 rm -v --        
         fi
-        find "$BACKUPS_DIRECTORY" -type f -name "${WORLDS_DIR}-*.zip" -printf '%T@ %p\0' | sort -z -n -r | cut -z -s -d " " -f "2-" | tail -z -n +$((BACKUPS_MAX_COUNT+1)) | xargs -0 rm -fv --
+        find "$BACKUPS_DIRECTORY" -type f -name "worlds-*.zip" -printf '%T@ %p\0' | sort -z -n -r | cut -z -s -d " " -f "2-" | tail -z -n +$((BACKUPS_MAX_COUNT+1)) | xargs -0 rm -fv --
     fi
 
     info "Removing backups older than $BACKUPS_MAX_AGE days"
     if [ "${BACKUPS_ZIP}" = true ]; then
-      find "$BACKUPS_DIRECTORY" -type f -mmin "+$((BACKUPS_MAX_AGE*60*24))" -name "${WORLDS_DIR}-*.zip" -print -exec rm -f "{}" \;
+      find "$BACKUPS_DIRECTORY" -type f -mmin "+$((BACKUPS_MAX_AGE*60*24))" -name "worlds-*.zip" -print -exec rm -f "{}" \;
     else
       find "$BACKUPS_DIRECTORY" -type f -mmin "+$((BACKUPS_MAX_AGE*60*24))" -name "AUTOBACKUP-${WORLD_NAME}-*.db" -print -exec rm -f "{}" \;
       find "$BACKUPS_DIRECTORY" -type f -mmin "+$((BACKUPS_MAX_AGE*60*24))" -name "AUTOBACKUP-${WORLD_NAME}-*.db.old" -print -exec rm -f "{}" \;


### PR DESCRIPTION
With version 0.209.8, Valheim now saves worlds in `/config/worlds_local` rather than `/config/worlds`. I have attempted to patch the scripts to use this new path. I tested lightly, but there are likely to be some bugs.
