### PR TITLE
Refactor worlds backup

### DIFF
--- a/common
+++ b/common
@@ -66,6 +66,10 @@ supervisor_syslog_conf=/usr/local/etc/supervisor/conf.d/syslog.conf
 # File containing the git commit shasum this image was build with
 git_commit_file=/usr/local/etc/git-commit.HEAD
 
+# Worlds directories
+old_worlds_dir="/config/worlds"
+worlds_dir="/config/worlds_local"
+
 # log levels
 debug=50
 info=40
@@ -110,20 +114,6 @@ printline() {
 }
 
 
-get_worlds_dir() {
-    worlds_dir="/config/worlds_local"
-    if [ ! -d "${worlds_dir}" ]; then
-        if [ ! -d "/config/worlds" ]; then
-            debug "No Valheim worlds to backup"
-            return
-        else
-            worlds_dir="/config/worlds"
-        fi
-    fi
-    echo "$worlds_dir"
-}
-
-
 ensure_permissions() {
     local restore_errexit=false
     if [ -o errexit ]; then
@@ -132,7 +122,11 @@ ensure_permissions() {
     fi
     chmod "$CONFIG_DIRECTORY_PERMISSIONS" /config
     chmod -f "$CONFIG_FILE_PERMISSIONS" /config/*.txt
-    worlds_dir="$(get_worlds_dir)"
+    # Legacy worlds directory
+    if [ -d "$old_worlds_dir" ]; then
+        chmod "$WORLDS_DIRECTORY_PERMISSIONS" "$old_worlds_dir"
+        chmod "$WORLDS_FILE_PERMISSIONS" "${old_worlds_dir}/"*
+    fi
     if [ -d "$worlds_dir" ]; then
         chmod "$WORLDS_DIRECTORY_PERMISSIONS" "$worlds_dir"
         chmod "$WORLDS_FILE_PERMISSIONS" "${worlds_dir}/"*

--- a/valheim-backup
+++ b/valheim-backup
@@ -121,10 +121,10 @@ flush_old() {
     if [ "$BACKUPS_MAX_COUNT" -gt 0 ]; then
         info "Removing all but the newest $BACKUPS_MAX_COUNT backups"
         if [ "${BACKUPS_ZIP}" = true ]; then
-            find "$BACKUPS_DIRECTORY" -type f -name "worlds-*.zip" -printf '%T@ %p\0' | sort -z -n -r | cut -z -s -d " " -f "2-" | tail -z -n +$((BACKUPS_MAX_COUNT+1)) | xargs -0 rm -fv --
+            find "$BACKUPS_DIRECTORY" -type f -name "worlds-*.zip" -printf '%T@ %p\0' | sort -z -n -r | cut -z -s -d " " -f "2-" | tail -z -n +$((BACKUPS_MAX_COUNT+1)) | xargs -0 rm -fv -- 2>/dev/null
         else
             for extension in {db,fwl,db.old,fwl.old}; do
-                find "$BACKUPS_DIRECTORY" -type f -name "AUTOBACKUP-${WORLD_NAME}-*.${extension}" -printf '%T@ %p\0' | sort -z -n -r | cut -z -s -d " " -f "2-" | tail -z -n +$((BACKUPS_MAX_COUNT+1)) | xargs -0 rm -v --
+                find "$BACKUPS_DIRECTORY" -type f -name "AUTOBACKUP-${WORLD_NAME}-*.${extension}" -printf '%T@ %p\0' | sort -z -n -r | cut -z -s -d " " -f "2-" | tail -z -n +$((BACKUPS_MAX_COUNT+1)) | xargs -0 rm -v -- 2>/dev/null
             done
         fi
     fi

--- a/valheim-backup
+++ b/valheim-backup
@@ -46,6 +46,7 @@ main() {
 
 backup() {
     local backup_file
+    local WORLDS_DIR
     if [ -d "$worlds_dir" ]; then
         WORLDS_DIR=$worlds_dir
     elif [ -d "$old_worlds_dir" ]; then
@@ -66,38 +67,22 @@ backup() {
         chmod "$BACKUPS_FILE_PERMISSIONS" "$backup_file"
         post_backup_hook "$backup_file"
     else
-        find "${WORLDS_DIR}/" -name "${WORLD_NAME}.db" -type f || info "Could not find .db world file for world ${WORLD_NAME}"
-        backup_file="$BACKUPS_DIRECTORY/AUTOBACKUP-${WORLD_NAME}-$(date +%Y%m%d-%H%M%S).db"
-        pre_backup_hook "$backup_file"
-        info "Backing up Valheim server world file ${WORLD_NAME}.db to $backup_file"
-        cp -v "${WORLDS_DIR}/${WORLD_NAME}.db" "${backup_file}"
-        chmod "$BACKUPS_FILE_PERMISSIONS" "$backup_file"
-        post_backup_hook "$backup_file"
-        
-        find "${WORLDS_LOCAL}/" -name "${WORLD_NAME}.fwl" -type f || info "Could not find .fwl file for world ${WORLD_NAME}"
-        backup_file="$BACKUPS_DIRECTORY/AUTOBACKUP-${WORLD_NAME}-$(date +%Y%m%d-%H%M%S).fwl"
-        pre_backup_hook "$backup_file"
-        info "Backing up Valheim server .fwl file ${WORLD_NAME}.fwl to $backup_file"
-        cp -v "${WORLDS_DIR}/${WORLD_NAME}.fwl" "${backup_file}"
-        chmod "$BACKUPS_FILE_PERMISSIONS" "$backup_file"
-        post_backup_hook "$backup_file"
-        
-        find "${WORLDS_DIR}/" -name "${WORLD_NAME}.db.old" -type f || info "Could not find .db.old world file for world ${WORLD_NAME}"
-        backup_file="$BACKUPS_DIRECTORY/AUTOBACKUP-${WORLD_NAME}-$(date +%Y%m%d-%H%M%S).db.old"
-        pre_backup_hook "$backup_file"
-        info "Backing up Valheim server world file ${WORLD_NAME}.db.old to $backup_file"
-        cp -v "${WORLDS_DIR}/${WORLD_NAME}.db.old" "${backup_file}"
-        chmod "$BACKUPS_FILE_PERMISSIONS" "$backup_file"
-        post_backup_hook "$backup_file"
-        
-        find "${WORLDS_DIR}/" -name "${WORLD_NAME}.fwl.old" -type f || info "Could not find .fwl.old file for world ${WORLD_NAME}"
-        backup_file="$BACKUPS_DIRECTORY/AUTOBACKUP-${WORLD_NAME}-$(date +%Y%m%d-%H%M%S).fwl.old"
-        pre_backup_hook "$backup_file"
-        info "Backing up Valheim server .fwl.old file ${WORLD_NAME}.fwl.old to $backup_file"
-        cp -v "${WORLDS_DIR}/${WORLD_NAME}.fwl.old" "${backup_file}"
-        chmod "$BACKUPS_FILE_PERMISSIONS" "$backup_file"
-        post_backup_hook "$backup_file"
-        
+        local world_file
+        local backup_suffix=$(date +%Y%m%d-%H%M%S)
+        for extension in {db,fwl,db.old,fwl.old}
+        do
+            world_file="$WORLD_NAME.$extension"
+            if [ ! -f "$world_file" ]; then
+                debug "World file $world_file not found - skipping"
+                continue
+            fi
+            backup_file="$BACKUPS_DIRECTORY/AUTOBACKUP-${WORLD_NAME}-$backup_suffix.$extension"
+            pre_backup_hook "$backup_file"
+            info "Backing up Valheim server world file $world_file to $backup_file"
+            cp -v "$world_file" "$backup_file"
+            chmod "$BACKUPS_FILE_PERMISSIONS" "$backup_file"
+            post_backup_hook "$backup_file"
+        done
     fi
 }
 

--- a/valheim-backup
+++ b/valheim-backup
@@ -68,7 +68,9 @@ backup() {
         post_backup_hook "$backup_file"
     else
         local world_file
-        local backup_suffix=$(date +%Y%m%d-%H%M%S)
+        local backup_suffix
+        backup_suffix=$(date +%Y%m%d-%H%M%S)
+
         for extension in {db,fwl,db.old,fwl.old}
         do
             world_file="$WORLD_NAME.$extension"

--- a/valheim-backup
+++ b/valheim-backup
@@ -73,7 +73,7 @@ backup() {
 
         for extension in {db,fwl,db.old,fwl.old}
         do
-            world_file="$WORLD_NAME.$extension"
+            world_file="$WORLDS_DIR/$WORLD_NAME.$extension"
             if [ ! -f "$world_file" ]; then
                 debug "World file $world_file not found - skipping"
                 continue

--- a/valheim-backup
+++ b/valheim-backup
@@ -46,12 +46,15 @@ main() {
 
 backup() {
     local backup_file
-    WORLDS_DIR=$(get_worlds_dir)
-
-    if [ "${WORLDS_DIR}z" = "z" ]; then
+    if [ -d "$worlds_dir" ]; then
+        WORLDS_DIR=$worlds_dir
+    elif [ -d "$old_worlds_dir" ]; then
+        WORLDS_DIR=$old_worlds_dir
+    else
+        info "No worlds to backup"
         return
     fi
-    
+
     mkdir -p "$BACKUPS_DIRECTORY"
     chmod "$BACKUPS_DIRECTORY_PERMISSIONS" "$BACKUPS_DIRECTORY"
 
@@ -98,6 +101,7 @@ backup() {
     fi
 }
 
+
 pre_backup_hook() {
     local backup_file
     local pre_hook_cmd
@@ -127,8 +131,6 @@ flush_old() {
         debug "No old backups to remove"
         return
     fi
-
-    WORLDS_DIR=$(get_worlds_dir)
 
     if [ "$BACKUPS_MAX_COUNT" -gt 0 ]; then
         info "Removing all but the newest $BACKUPS_MAX_COUNT backups"

--- a/valheim-backup
+++ b/valheim-backup
@@ -71,8 +71,7 @@ backup() {
         local backup_suffix
         backup_suffix=$(date +%Y%m%d-%H%M%S)
 
-        for extension in {db,fwl,db.old,fwl.old}
-        do
+        for extension in {db,fwl,db.old,fwl.old}; do
             world_file="$WORLDS_DIR/$WORLD_NAME.$extension"
             if [ ! -f "$world_file" ]; then
                 debug "World file $world_file not found - skipping"
@@ -122,20 +121,21 @@ flush_old() {
     if [ "$BACKUPS_MAX_COUNT" -gt 0 ]; then
         info "Removing all but the newest $BACKUPS_MAX_COUNT backups"
         if [ "${BACKUPS_ZIP}" = true ]; then
-          find "$BACKUPS_DIRECTORY" -type f -name "worlds-*.zip" -printf '%T@ %p\0' | sort -z -n -r | cut -z -s -d " " -f "2-" | tail -z -n +$((BACKUPS_MAX_COUNT+1)) | xargs -0 rm -v --
+            find "$BACKUPS_DIRECTORY" -type f -name "worlds-*.zip" -printf '%T@ %p\0' | sort -z -n -r | cut -z -s -d " " -f "2-" | tail -z -n +$((BACKUPS_MAX_COUNT+1)) | xargs -0 rm -fv --
         else
-          find "$BACKUPS_DIRECTORY" -type f -name "AUTOBACKUP-${WORLD_NAME}-*.db" -printf '%T@ %p\0' | sort -z -n -r | cut -z -s -d " " -f "2-" | tail -z -n +$((BACKUPS_MAX_COUNT+1)) | xargs -0 rm -v --
-          find "$BACKUPS_DIRECTORY" -type f -name "AUTOBACKUP-${WORLD_NAME}-*.db.old" -printf '%T@ %p\0' | sort -z -n -r | cut -z -s -d " " -f "2-" | tail -z -n +$((BACKUPS_MAX_COUNT+1)) | xargs -0 rm -v --        
+            for extension in {db,fwl,db.old,fwl.old}; do
+                find "$BACKUPS_DIRECTORY" -type f -name "AUTOBACKUP-${WORLD_NAME}-*.${extension}" -printf '%T@ %p\0' | sort -z -n -r | cut -z -s -d " " -f "2-" | tail -z -n +$((BACKUPS_MAX_COUNT+1)) | xargs -0 rm -v --
+            done
         fi
-        find "$BACKUPS_DIRECTORY" -type f -name "worlds-*.zip" -printf '%T@ %p\0' | sort -z -n -r | cut -z -s -d " " -f "2-" | tail -z -n +$((BACKUPS_MAX_COUNT+1)) | xargs -0 rm -fv --
     fi
 
     info "Removing backups older than $BACKUPS_MAX_AGE days"
     if [ "${BACKUPS_ZIP}" = true ]; then
-      find "$BACKUPS_DIRECTORY" -type f -mmin "+$((BACKUPS_MAX_AGE*60*24))" -name "worlds-*.zip" -print -exec rm -f "{}" \;
+        find "$BACKUPS_DIRECTORY" -type f -mmin "+$((BACKUPS_MAX_AGE*60*24))" -name "worlds-*.zip" -print -exec rm -f "{}" \;
     else
-      find "$BACKUPS_DIRECTORY" -type f -mmin "+$((BACKUPS_MAX_AGE*60*24))" -name "AUTOBACKUP-${WORLD_NAME}-*.db" -print -exec rm -f "{}" \;
-      find "$BACKUPS_DIRECTORY" -type f -mmin "+$((BACKUPS_MAX_AGE*60*24))" -name "AUTOBACKUP-${WORLD_NAME}-*.db.old" -print -exec rm -f "{}" \;
+        for extension in {db,fwl,db.old,fwl.old}; do
+            find "$BACKUPS_DIRECTORY" -type f -mmin "+$((BACKUPS_MAX_AGE*60*24))" -name "AUTOBACKUP-${WORLD_NAME}-*.${extension}" -print -exec rm -f "{}" \;
+        done
     fi
 }
 


### PR DESCRIPTION
Refactor detection of new/old worlds directories. The last PR was throwing a ZIP error when started on an empty worlds directory.

```
Jun 26 20:26:25 /supervisord: valheim-backup INFO - Backing up Valheim server worlds to /config/backups/worlds-20220626-202625.zip
Jun 26 20:26:25 /supervisord: valheim-backup    zip warning: name not matched: DEBUG - [80] - No Valheim worlds to backup/
Jun 26 20:26:25 /supervisord: valheim-backup
Jun 26 20:26:25 /supervisord: valheim-backup zip error: Nothing to do! (try: zip -r /config/backups/worlds-20220626-202625.zip . -i DEBUG - [80] - No Valheim worlds to backup/)
Jun 26 20:26:25 /supervisord: valheim-backup chmod: cannot access '/config/backups/worlds-20220626-202625.zip': No such file or directory
```