### PR TITLE
Use Debian 10 for the 32-bit environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,28 +78,37 @@ RUN mkdir -p /usr/local/etc/supervisor/conf.d/ \
 RUN echo "${SOURCE_COMMIT:-unknown}" > /usr/local/etc/git-commit.HEAD
 
 
+FROM --platform=linux/386 debian:buster-slim as i386-libs
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update \
+    && apt-get -y --no-install-recommends install \
+        libc6-dev \
+        libstdc++6 \
+        libsdl2-2.0-0 \
+        libcurl4 \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+
 FROM debian:bullseye-slim
 ENV DEBIAN_FRONTEND=noninteractive
 COPY --from=build-env /usr/local/ /usr/local/
+COPY --from=i386-libs /lib/ld-linux.so.2 /lib/ld-linux.so.2
+COPY --from=i386-libs /lib/i386-linux-gnu /lib/i386-linux-gnu
+COPY --from=i386-libs /usr/lib/i386-linux-gnu /usr/lib/i386-linux-gnu
 COPY fake-supervisord /usr/bin/supervisord
 
 RUN groupadd -g "${PGID:-0}" -o valheim \
     && useradd -g "${PGID:-0}" -u "${PUID:-0}" -o --create-home valheim \
-    && dpkg --add-architecture i386 \
     && apt-get update \
     && apt-get -y --no-install-recommends install apt-utils \
     && apt-get -y dist-upgrade \
     && apt-get -y --no-install-recommends install \
         libc6-dev \
-        lib32stdc++6 \
-        lib32gcc-s1 \
         libsdl2-2.0-0 \
-        libsdl2-2.0-0:i386 \
         cron \
         curl \
         iproute2 \
         libcurl4 \
-        libcurl4:i386 \
         ca-certificates \
         procps \
         locales \


### PR DESCRIPTION
Some Synology users face a problem with glibc >= 2.31 due to collisions in the syscall number assignments.  Synology uses some that have since been used for other things in mainline Linux.  The one that exposed the issue here is clock_gettime64 being #403 in mainline Linux while in the Synology kernel exhibiting the issue it is SYNOArchiveBit.  Suffice it to say these functions are not interchangeable.  It seems that glibc can not tell the difference and working around the issue is required.

This seemed as clean as providing a wrapper library using LD_PRELOAD that ensured none of the 32-bit programs this image cared about would step on the wrong syscalls, because it is difficult to control what programs may call what other programs.  This is admittedly a little dirty, since the x86_64 execution will be using glibc 2.31 and the i386 environment will be using 2.28.

In practice I did not see any adverse effects, but it is not heavily exercised.  Just in launching valheim-server with -crossplay and ensuring libpary.so loaded successfully.