### PR TITLE
Kill any hung steamcmd processes (fixes #536)

### DIFF
--- a/valheim-updater
+++ b/valheim-updater
@@ -127,6 +127,10 @@ check_mod() {
 
 
 download_valheim() {
+    # Kill any hung steamcmd processes
+    pkill -TERM steamcmd || true
+    sleep 1
+    pkill -KILL steamcmd || true
     # shellcheck disable=SC2086
     /opt/steamcmd/steamcmd.sh +force_install_dir "$valheim_download_path" +login anonymous +app_update 896660 $STEAMCMD_ARGS +quit
 }


### PR DESCRIPTION
Apparently steamcmd sometimes gets stuck. In #536 @billputer came up with this pragmatic way of ensuring it is not running prior to running the update.