### PR TITLE
Make it easy to run public test releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Without it you will see a message `Warning: failed to set thread priority` in th
 | `BACKUPS_ZIP` | `true` | Compress Backups with `zip`. If set to `false` Backups will be stored uncompressed. |
 | `PERMISSIONS_UMASK` | `022` | [Umask](https://en.wikipedia.org/wiki/Umask) to use for backups, config files and directories |
 | `STEAMCMD_ARGS` | `validate` | Additional steamcmd CLI arguments |
+| `PUBLIC_TEST` | `false` | Run the Public Test Beta version of Valheim server. Note that this simply extends existing `STEAMCMD_ARGS` by adding the appropriate beta flags to it. |
 | `VALHEIM_PLUS` | `false` | Whether [ValheimPlus](https://github.com/valheimPlus/ValheimPlus) mod should be loaded (config in `/config/valheimplus`, additional plugins in `/config/valheimplus/plugins`). Can not be used together with `BEPINEX`. |
 | `VALHEIM_PLUS_RELEASE` | `latest` | Which version of [ValheimPlus](https://github.com/valheimPlus/ValheimPlus) to download. Will default to latest available. To specify a specific tag set to `tags/0.9.9.8` |
 | `BEPINEX` | `false` | Whether [BepInExPack Valheim](https://valheim.thunderstore.io/package/denikson/BepInExPack_Valheim/) mod should be loaded (config in `/config/bepinex`, plugins in `/config/bepinex/plugins`). Can not be used together with `VALHEIM_PLUS`. |

--- a/defaults
+++ b/defaults
@@ -22,6 +22,12 @@ SERVER_PUBLIC=${SERVER_PUBLIC:-1}
 # steamcmd.sh arguments
 STEAMCMD_ARGS=${STEAMCMD_ARGS-validate}
 
+# Public Test
+PUBLIC_TEST=${PUBLIC_TEST:-false}
+if [ "$PUBLIC_TEST" = true ]; then
+    STEAMCMD_ARGS="$STEAMCMD_ARGS -beta public-test -betapassword yesimadebackups"
+fi
+
 # Debug Flags
 # Flag to wipe all downloaded server data on startup (config is untouched)
 DEBUG_START_FRESH=${DEBUG_START_FRESH:-false}
@@ -146,4 +152,3 @@ POST_BEPINEX_CONFIG_HOOK=${POST_BEPINEX_CONFIG_HOOK:-}
 ADMINLIST_IDS=${ADMINLIST_IDS:-}
 BANNEDLIST_IDS=${BANNEDLIST_IDS:-}
 PERMITTEDLIST_IDS=${PERMITTEDLIST_IDS:-}
-


### PR DESCRIPTION
This adds a flag that can be toggled and in turn modifies steamcmd args to either use the default or the beta branch.