### PR TITLE
Fix rebooting when players are online.

### DIFF
--- a/valheim-bootstrap
+++ b/valheim-bootstrap
@@ -80,6 +80,8 @@ write_permittedlist
 
 # Create crontabs
 crontab=$(mktemp)
+echo "SERVER_PORT=$SERVER_PORT" >>"$crontab"
+echo "STATUS_HTTP_HTDOCS=$STATUS_HTTP_HTDOCS" >> "$crontab"
 if [ "$BACKUPS" = true ] && [ -n "$BACKUPS_CRON" ] && [ "$BACKUPS_INTERVAL" = "315360000" ]; then
     debug "Creating cron to do world backups using schedule $BACKUPS_CRON"
     echo "$BACKUPS_CRON [ -f \"$valheim_backup_pidfile\" ] && kill -HUP \$(cat $valheim_backup_pidfile)" >> "$crontab"


### PR DESCRIPTION
When the cron job for the daily reboot launches valheim_is_idle which subsequently launches valheim-status, valheim-status does not have the environment variables it needs and falls back to defaults. On servers that are not using the default ports this causes the status to timeout which is treated as 0 players online resulting in a reboot even when players are online.

This patch modifies the crontab file so that the cron environment will have SERVER_PORT and STATUS_HTTP_HTDOCS which are the 2 parameters that valheim-status tries to get from the environment.