### PR TITLE
Add SERVER_PUBLIC to cron environment

### DIFF
--- a/valheim-bootstrap
+++ b/valheim-bootstrap
@@ -80,8 +80,11 @@ write_permittedlist
 
 # Create crontabs
 crontab=$(mktemp)
-echo "SERVER_PORT=$SERVER_PORT" >>"$crontab"
-echo "STATUS_HTTP_HTDOCS=$STATUS_HTTP_HTDOCS" >> "$crontab"
+
+{ echo "SERVER_PUBLIC=$SERVER_PUBLIC"; \
+    echo "SERVER_PORT=$SERVER_PORT"; \
+    echo "STATUS_HTTP_HTDOCS=$STATUS_HTTP_HTDOCS"; } >> "$crontab"
+
 if [ "$BACKUPS" = true ] && [ -n "$BACKUPS_CRON" ] && [ "$BACKUPS_INTERVAL" = "315360000" ]; then
     debug "Creating cron to do world backups using schedule $BACKUPS_CRON"
     echo "$BACKUPS_CRON [ -f \"$valheim_backup_pidfile\" ] && kill -HUP \$(cat $valheim_backup_pidfile)" >> "$crontab"


### PR DESCRIPTION
When SERVER_PUBLIC is set to false the server does not respond on the query port.  When server_is_idle() is run under cron environment SERVER_PUBLIC is unset and defaults to true causing the function to attempt to use the query port.

This patch adds SERVER_PUBLIC to the cron environment so that server_is_idle() will use the correct path for determining if players are online.

See #551 Restart if idle only restarts when NOT idle.