### PR TITLE
Space character in .env file

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,7 @@ Some characters that are allowed as section names in the config files are not al
 | `_HYPHEN_` | `-` |
 | `_UNDERSCORE_` | `_` |
 | `_PLUS_` | `+` |
+| `_SPACE_` | ` ` |
 
 Example:
 ```

--- a/env2cfg/env2cfg/__init__.py
+++ b/env2cfg/env2cfg/__init__.py
@@ -17,6 +17,7 @@ _PRE_TRANSLATE = {
     "_DOT_": ".",
     "_HYPHEN_": "-",
     "_PLUS_": "+",
+    "_SPACE_": " ",
     "_UNDERSCORE_": "@UNDERSCORE@",
 }
 


### PR DESCRIPTION
Can I suggest to add the space character to the translation table?
I'm honestly not 100% sure that this small change in the "_PRE_TRANSLATE" dictionary is enough to add it, i'm a python (and docker) beginner, but there's no harm in trying.

I'm actually using the POST_BEPINEX_CONFIG_HOOK event hook and env2cfg to create/modify some configs for some plugins.
The config "neanka.def_handy_portals.cfg" (from "[Handy portals](https://www.nexusmods.com/valheim/mods/471)" plugin) is using space character in his section names so docker gives me the error "key cannot contain a space" when using docker compose up.

For example, this is a part of the config:
```
## Settings file was created by plugin DEF handy portals v1.0.0.7
## Plugin GUID: neanka.def_handy_portals

[Cheat]

## Allow teleport with restricted items
# Setting type: Boolean
# Default value: false
Allow teleport with restricted items = false
```
This, in the .env file, doesn't work and docker gives the error "key cannot contain a space":

```
POST_BEPINEX_CONFIG_HOOK=env2cfg --verbose --config /config/bepinex/neanka.def_handy_portals.cfg --env-prefix HANDYPORTALS_
HANDYPORTALS_Cheat_Allow teleport with restricted items=true
```
Adding the space character in the Translation table should allow something like this to work:
```
POST_BEPINEX_CONFIG_HOOK=env2cfg --verbose --config /config/bepinex/neanka.def_handy_portals.cfg --env-prefix HANDYPORTALS_
HANDYPORTALS_Cheat_Allow_SPACE_teleport_SPACE_with_SPACE_restricted_SPACE_items=true
```
Thank you for your time 😄