### PR TITLE
Add param to rsync for mods that will remove unused mods

### DIFF
--- a/common
+++ b/common
@@ -284,7 +284,7 @@ write_bepinex_config() {
         fi
         if [ -d "$config_path/plugins" ] && [ -d "$plugins_path" ]; then
             info "Syncing BepInEx plugins from $config_path/plugins/ -> $plugins_path"
-            rsync -a --itemize-changes "$config_path/plugins/" "$plugins_path"
+            rsync -a --delete --itemize-changes "$config_path/plugins/" "$plugins_path"
         fi
     fi
     if [ -n "$POST_BEPINEX_CONFIG_HOOK" ]; then


### PR DESCRIPTION
This will ensure a strict sync between the config plugins folder and the server's plugins folder.  That way if a mod is deleted in the config folder, it will also be removed from the server.