### PR TITLE
fix the URL of the Thunderstore.io API call to get BepInExPack (fixes #665)

### DIFF
--- a/bepinex-updater
+++ b/bepinex-updater
@@ -15,7 +15,7 @@ main() {
     local download_url
     local remote_updated_at
 
-    if ! api_response=$(curl -sfSL -H "accept: application/json" "https://valheim.thunderstore.io/api/experimental/package/denikson/BepInExPack_Valheim/"); then
+    if ! api_response=$(curl -sfSL -H "accept: application/json" "https://thunderstore.io/api/experimental/package/denikson/BepInExPack_Valheim/"); then
         fatal "Error: could not retrieve BepInEx release info from Thunderstore.io API"
     fi
     download_url=$(jq -r  ".latest.download_url" <<< "$api_response" )


### PR DESCRIPTION
Edit:
For a temporary manual fix until this PR is merged and the image is updated, please check @erNail's comment here 
https://github.com/lloesche/valheim-server-docker/pull/666#issuecomment-2028473407