### PR TITLE
Add tini and process reaping

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -133,6 +133,7 @@ RUN groupadd -g "${PGID:-0}" -o valheim \
     libpulse-dev \
     libatomic1 \
     libc6 \
+    tini \
     && echo 'LANG="en_US.UTF-8"' > /etc/default/locale \
     && echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen \
     && rm -f /bin/sh \

--- a/bootstrap
+++ b/bootstrap
@@ -13,7 +13,7 @@ main() {
     setup_supervisor_http_server
     setup_status_http_server
     pre_supervisor_hook
-    exec /usr/local/bin/supervisord -c /usr/local/etc/supervisord.conf
+    exec /usr/bin/tini -- /usr/local/bin/supervisord -c /usr/local/etc/supervisord.conf
 }
 
 

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -46,8 +46,6 @@ autostart=true
 autorestart=false
 startsecs=0
 startretries=0
-stopasgroup=true
-killasgroup=true
 priority=30
 
 [program:valheim-server]
@@ -63,8 +61,6 @@ autorestart=true
 startsecs=10
 startretries=10
 stopwaitsecs=90
-stopasgroup=true
-killasgroup=true
 priority=90
 
 [program:valheim-updater]

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -30,6 +30,8 @@ stdout_logfile_maxbytes=1MB
 stderr_logfile_maxbytes=1MB
 autostart=true
 autorestart=true
+stopasgroup=true
+killasgroup=true
 priority=20
 
 [program:valheim-bootstrap]
@@ -44,6 +46,8 @@ autostart=true
 autorestart=false
 startsecs=0
 startretries=0
+stopasgroup=true
+killasgroup=true
 priority=30
 
 [program:valheim-server]
@@ -59,6 +63,8 @@ autorestart=true
 startsecs=10
 startretries=10
 stopwaitsecs=90
+stopasgroup=true
+killasgroup=true
 priority=90
 
 [program:valheim-updater]
@@ -71,6 +77,8 @@ stdout_logfile_maxbytes=1MB
 stderr_logfile_maxbytes=1MB
 autostart=false
 autorestart=true
+stopasgroup=true
+killasgroup=true
 priority=50
 
 [program:valheim-backup]
@@ -83,6 +91,8 @@ stdout_logfile_maxbytes=1MB
 stderr_logfile_maxbytes=1MB
 autostart=false
 autorestart=true
+stopasgroup=true
+killasgroup=true
 priority=50
 
 [include]


### PR DESCRIPTION
This PR adds tini as PID 1 as users have reported that running docker compose with `init: true` fixes a "5am server restart bug" where valheim-server processes stay around defunct. I was not able to reproduce this behavior and supervisord should reap any defunct children, but since tini uses very little resources it doesn't harm to have it as PID 1 and perform process reaping where supervisord might fail in some environments.