### PR TITLE
Run server in separate process group

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim as build-env
+FROM debian:bullseye-slim AS build-env
 ENV DEBIAN_FRONTEND=noninteractive
 ARG TESTS
 ARG SOURCE_COMMIT
@@ -88,7 +88,7 @@ RUN mkdir -p /usr/local/etc/supervisor/conf.d/ \
 RUN echo "${SOURCE_COMMIT:-unknown}" > /usr/local/etc/git-commit.HEAD
 
 
-FROM --platform=linux/386 debian:buster-slim as i386-libs
+FROM --platform=linux/386 debian:buster-slim AS i386-libs
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
     && apt-get -y --no-install-recommends install \

--- a/README.md
+++ b/README.md
@@ -135,11 +135,11 @@ Without it you will see a message `Warning: failed to set thread priority` in th
 | `IDLE_DATAGRAM_WINDOW` | `3` | The time window, in seconds, to wait for incoming UDP datagrams on non-public servers before determining if the server is idle |
 | `IDLE_DATAGRAM_MAX_COUNT` | `30` | The number of incoming UDP datagrams the container should tolerate (including useless datagrams such as mDNS, as well as useful datagrams like queries against the UDP query port and active connections by players) on non-public servers before deciding that the server is not idle |
 | `UPDATE_IF_IDLE` | `true` | Only run update check if no players are connected to the server (`true` or `false`) |
-| `RESTART_CRON` | `0 5 * * *` | [Cron schedule](https://en.wikipedia.org/wiki/Cron#Overview) for server restarts (disabled if set to an empty string) |
+| `RESTART_CRON` | `10 5 * * *` | [Cron schedule](https://en.wikipedia.org/wiki/Cron#Overview) for server restarts (disabled if set to an empty string) |
 | `RESTART_IF_IDLE` | `true` | Only run daily restart if no players are connected to the server (`true` or `false`) |
 | `TZ` | `Etc/UTC` | Container [time zone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) |
 | `BACKUPS` | `true` | Whether the server should create periodic backups (`true` or `false`) |
-| `BACKUPS_CRON` | `0 * * * *` | [Cron schedule](https://en.wikipedia.org/wiki/Cron#Overview) for world backups (disabled if set to an empty string or if the legacy `BACKUPS_INTERVAL` is set) |
+| `BACKUPS_CRON` | `5 * * * *` | [Cron schedule](https://en.wikipedia.org/wiki/Cron#Overview) for world backups (disabled if set to an empty string or if the legacy `BACKUPS_INTERVAL` is set) |
 | `BACKUPS_DIRECTORY` | `/config/backups` | Path to the backups directory |
 | `BACKUPS_MAX_AGE` | `3` | Age in days after which old backups are flushed |
 | `BACKUPS_MAX_COUNT` | `0` | Maximum number of backups kept, 0 means infinity |

--- a/defaults
+++ b/defaults
@@ -60,14 +60,14 @@ UPDATE_IF_IDLE=${UPDATE_IF_IDLE:-true}
 
 # What time we restart the valheim-server
 # This is usful to mitigate the effects of memory/resource leaks
-RESTART_CRON=${RESTART_CRON-0 5 * * *}
+RESTART_CRON=${RESTART_CRON-10 5 * * *}
 RESTART_IF_IDLE=${RESTART_IF_IDLE:-true}
 
 # World backup related settings
 BACKUPS=${BACKUPS:-true}
 # Legacy interval variable used to be 3600 (1h)
 BACKUPS_INTERVAL=${BACKUPS_INTERVAL:-315360000}
-BACKUPS_CRON=${BACKUPS_CRON-0 * * * *}
+BACKUPS_CRON=${BACKUPS_CRON-5 * * * *}
 BACKUPS_DIRECTORY=${BACKUPS_DIRECTORY:-/config/backups}
 BACKUPS_MAX_AGE=${BACKUPS_MAX_AGE:-3}
 BACKUPS_MAX_COUNT=${BACKUPS_MAX_COUNT:-0}

--- a/valheim-server
+++ b/valheim-server
@@ -109,7 +109,7 @@ run_server() {
 
     chmod +x "$valheim_server"
     # shellcheck disable=SC2086
-    LD_PRELOAD=$SERVER_LD_PRELOAD "$valheim_server" -nographics -batchmode -name "$SERVER_NAME" -port "$SERVER_PORT" -world "$WORLD_NAME" -public "$SERVER_PUBLIC" "${password_args[@]}" $SERVER_ARGS > >(filter) 2>&1 &
+    LD_PRELOAD=$SERVER_LD_PRELOAD setsid "$valheim_server" -nographics -batchmode -name "$SERVER_NAME" -port "$SERVER_PORT" -world "$WORLD_NAME" -public "$SERVER_PUBLIC" "${password_args[@]}" $SERVER_ARGS > >(filter) 2>&1 &
     valheim_server_pid=$!
     unset LD_LIBRARY_PATH
     unset LD_PRELOAD
@@ -193,13 +193,13 @@ shutdown() {
     fi
     pre_server_shutdown_hook
     info "Shutting down Valheim server with PID $valheim_server_pid"
-    kill -INT $valheim_server_pid
+    kill -INT -$valheim_server_pid
     shutdown_timeout=$(($(date +%s)+timeout))
     while [ -d "/proc/$valheim_server_pid" ]; do
         if [ "$(date +%s)" -gt $shutdown_timeout ]; then
             shutdown_timeout=$(($(date +%s)+timeout))
-            warn "Timeout while waiting for server to shut down - sending SIG$kill_signal to PID $valheim_server_pid"
-            kill -$kill_signal $valheim_server_pid
+            warn "Timeout while waiting for server to shut down - sending SIG$kill_signal to PGID $valheim_server_pid"
+            kill -$kill_signal -$valheim_server_pid
             case "$kill_signal" in
                 INT)
                     kill_signal=TERM


### PR DESCRIPTION
This might help with the defunct / dangling server processes on restart. Instead of only tracking the server process itself, we're starting the server in a separate process group and kill the entire group on shutdown/restart.

This PR also shifts the default RESTART and BACKUP crons by 5 minutes, so there's less potential for conflicts.