### PR TITLE
Ensure that valheim-server gets killed as dedicated process group

### DIFF
--- a/supervisord.conf
+++ b/supervisord.conf
@@ -46,6 +46,8 @@ autostart=true
 autorestart=false
 startsecs=0
 startretries=0
+stopasgroup=false
+killasgroup=false
 priority=30
 
 [program:valheim-server]
@@ -61,6 +63,8 @@ autorestart=true
 startsecs=10
 startretries=10
 stopwaitsecs=90
+stopasgroup=false
+killasgroup=true
 priority=90
 
 [program:valheim-updater]


### PR DESCRIPTION
If the server for whatever reason times out, this will make sure that not only the server process but all of its spawned child processes are killed as a group.