### PR TITLE
Revert setsid for BepInEx compatibility

### DIFF
--- a/valheim-server
+++ b/valheim-server
@@ -109,7 +109,7 @@ run_server() {
 
     chmod +x "$valheim_server"
     # shellcheck disable=SC2086
-    LD_PRELOAD=$SERVER_LD_PRELOAD setsid "$valheim_server" -nographics -batchmode -name "$SERVER_NAME" -port "$SERVER_PORT" -world "$WORLD_NAME" -public "$SERVER_PUBLIC" "${password_args[@]}" $SERVER_ARGS > >(filter) 2>&1 &
+    LD_PRELOAD=$SERVER_LD_PRELOAD "$valheim_server" -nographics -batchmode -name "$SERVER_NAME" -port "$SERVER_PORT" -world "$WORLD_NAME" -public "$SERVER_PUBLIC" "${password_args[@]}" $SERVER_ARGS > >(filter) 2>&1 &
     valheim_server_pid=$!
     unset LD_LIBRARY_PATH
     unset LD_PRELOAD
@@ -193,13 +193,13 @@ shutdown() {
     fi
     pre_server_shutdown_hook
     info "Shutting down Valheim server with PID $valheim_server_pid"
-    kill -INT -$valheim_server_pid
+    kill -INT $valheim_server_pid
     shutdown_timeout=$(($(date +%s)+timeout))
     while [ -d "/proc/$valheim_server_pid" ]; do
         if [ "$(date +%s)" -gt $shutdown_timeout ]; then
             shutdown_timeout=$(($(date +%s)+timeout))
             warn "Timeout while waiting for server to shut down - sending SIG$kill_signal to PGID $valheim_server_pid"
-            kill -$kill_signal -$valheim_server_pid
+            kill -$kill_signal $valheim_server_pid
             case "$kill_signal" in
                 INT)
                     kill_signal=TERM


### PR DESCRIPTION
This temporarily reverts the process group patch, as it creates compatibility issues with BepInEx/ValheimPlus.