### PR TITLE
updated Dockerfile to use bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim AS build-env
+FROM debian:bookworm-slim AS build-env
 ENV DEBIAN_FRONTEND=noninteractive
 ARG TESTS
 ARG SOURCE_COMMIT
@@ -8,7 +8,7 @@ ARG GO_VERSION=1.24.1
 
 RUN apt-get update
 RUN apt-get -y install apt-utils
-RUN apt-get -y install build-essential curl git python3 python3-pip shellcheck
+RUN apt-get -y install build-essential curl git python3 python3-pip pipx shellcheck
 
 # Install Go 1.24 manually
 RUN curl -L -o /tmp/go${GO_VERSION}.linux-amd64.tar.gz https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz \
@@ -28,8 +28,9 @@ RUN curl -L -o /tmp/busybox.tar.bz2 https://busybox.net/downloads/busybox-${BUSY
 
 WORKDIR /build/env2cfg
 COPY ./env2cfg/ /build/env2cfg/
+ENV PATH="/root/.local/bin:${PATH}"
 RUN if [ "${TESTS:-true}" = true ]; then \
-    pip3 install tox \
+    pipx ensurepath && pipx install tox \
     && tox \
     ; \
     fi
@@ -93,7 +94,7 @@ RUN mkdir -p /usr/local/etc/supervisor/conf.d/ \
 RUN echo "${SOURCE_COMMIT:-unknown}" > /usr/local/etc/git-commit.HEAD
 
 
-FROM --platform=linux/386 debian:buster-slim AS i386-libs
+FROM --platform=linux/386 debian:bookworm-slim AS i386-libs
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
     && apt-get -y --no-install-recommends install \
@@ -104,7 +105,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 ENV DEBIAN_FRONTEND=noninteractive
 COPY --from=build-env /usr/local/ /usr/local/
 COPY --from=i386-libs /lib/ld-linux.so.2 /lib/ld-linux.so.2


### PR DESCRIPTION
## Summary of work
- updated all references to bookworm
- added pipx to allow system install of python tox
- added new PATH to allow tox to be seen

## important considerations
I was unable to build with TESTS=true due to the line starting with "shellcheck -a -x -s bash -e SC2034"
it was not happy with a whole bunch of the sh files so i skipped, it, i tested bepinex and confirm this fixed the out of date GLIB library.
