### PR TITLE
Revert to GHCR_PAT

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     tags:
-      - 'v*'
+      - "v*"
   pull_request:
     branches:
       - main
@@ -109,14 +109,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-#      - name: Login to Docker Hub
-#        if: github.event_name != 'pull_request'
-#        uses: docker/login-action@v3
-#        with:
-#          username: ${{ vars.DOCKERHUB_USERNAME }}
-#          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          password: ${{ secrets.GHCR_PAT }}
 
       - name: Docker meta
         id: meta


### PR DESCRIPTION
Looks like GitHub does not allow a repo to publish a package to a different name than the repo name itself using the default `GITHUB_TOKEN`. I switched the repo's Action permissions to read/write but am still getting
```
Error: buildx failed with: ERROR: failed to build: failed to solve: failed to push ghcr.io/community-valheim-tools/valheim-server:sha-f620484: denied: permission_denied: write_package
```

I believe that's the reason I originally used a custom `GHCR_PAT`. After moving the repo from `lloesche/valheim-server-docker` to the `community-valheim-tools` org, it also moved all secrets, which caused the token to be invalid for this repo and needs to be re-created.