### PR TITLE
Dropped access to unnecessary kernel capabilities in docker compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,8 +1,15 @@
 services:
   valheim:
     image: ghcr.io/community-valheim-tools/valheim-server
+    cap_drop:
+      - ALL
+      - SYS_MODULE
     cap_add:
       - sys_nice
+      - CHOWN
+      - SETUID
+      - SETGID
+      - KILL
     volumes:
       - $HOME/valheim-server/config:/config
       - $HOME/valheim-server/data:/opt/valheim


### PR DESCRIPTION
In this configuration, all capabilities are first removed, then only the necessary capabilities are reintroduced.

Allowed capabilities:
- sys_nice  # adjusting process priority (I assume)
- CHOWN     # changing file ownership
- SETUID    # allows changing user
- SETGID    # allows changing user group
- KILL      # allows killing processes

This set of necessary capabilities were found with manual testings, including starting, playing and stopping the server. With this set no errors were observed.

If someone were to use privileged ports (<1024) for some reason, they'd also need
- NET_BIND_SERVICE

Capability `SYS_MODULE` is explicitly removed. Though listing it after `ALL` is redundant, it's there as a safeguard in case anyone removes `ALL` for any reason. `SYS_MODULE` is considered a high risk capability in containers.